### PR TITLE
Feature/toobar custom

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/common/custom/CustomToolbar.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/custom/CustomToolbar.kt
@@ -1,0 +1,105 @@
+package com.woowa.banchan.ui.common.custom
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Base64
+import android.view.LayoutInflater
+import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.databinding.DataBindingUtil
+import com.woowa.banchan.R
+import com.woowa.banchan.databinding.ViewToolBarCustomBinding
+import java.io.ByteArrayInputStream
+import java.io.ObjectInputStream
+
+class CustomToolbar(
+    context: Context,
+    attrs: AttributeSet?
+) : ConstraintLayout(context, attrs) {
+
+    private val binding: ViewToolBarCustomBinding =
+        DataBindingUtil.inflate(
+            LayoutInflater.from(context),
+            R.layout.view_tool_bar_custom,
+            this,
+            true
+        )
+    private val currentMode: Int
+
+    init {
+        val a = context.obtainStyledAttributes(attrs, R.styleable.CustomToolbar)
+        currentMode = a.getInt(R.styleable.CustomToolbar_toolBarType, 0)
+
+        with(binding) {
+            // title 설정
+            tvTitle.text = a.getString(R.styleable.CustomToolbar_toolbarTitle).toString()
+
+            // mode에 따른 보여지는 view 설정
+            ivBack.isVisible = currentMode != 0x00
+            ivRefresh.isVisible = currentMode == 0x03
+            layoutMainIcons.isVisible = currentMode == 0x00
+            unSetUserNotifierIcon()
+            setCartCountIcon(0)
+
+            // 기본 버튼 설정
+            ivBack.setOnClickListener {
+                val callBackStr = a.getString(R.styleable.CustomToolbar_onClickBackIcon)
+                    ?: return@setOnClickListener
+                createCallBackFunc(callBackStr)()
+            }
+            ivUser.setOnClickListener {
+                val callBackStr = a.getString(R.styleable.CustomToolbar_onClickUserIcon)
+                    ?: return@setOnClickListener
+                createCallBackFunc(callBackStr)()
+            }
+            ivCart.setOnClickListener {
+                val callBackStr = a.getString(R.styleable.CustomToolbar_onClickCartIcon)
+                    ?: return@setOnClickListener
+                createCallBackFunc(callBackStr)()
+            }
+            ivRefresh.setOnClickListener {
+                val callBackStr = a.getString(R.styleable.CustomToolbar_onClickRefreshIcon)
+                    ?: return@setOnClickListener
+                createCallBackFunc(callBackStr)()
+            }
+
+        }
+        a.recycle()
+    }
+
+    fun setOnClickBackIcon(c: () -> Unit) = binding.ivBack.setOnClickListener { c() }
+    fun setOnClickCartIcon(c: () -> Unit) = binding.ivCart.setOnClickListener { c() }
+    fun setOnClickUserIcon(c: () -> Unit) = binding.ivUser.setOnClickListener { c() }
+    fun setOnClickRefreshIcon(c: () -> Unit) = binding.ivRefresh.setOnClickListener { c() }
+
+    fun setUserNotifierIcon() {
+        if (currentMode == 0x00) binding.ivUserBlackDot.isVisible = true
+    }
+
+    fun unSetUserNotifierIcon() {
+        if (currentMode == 0x00) binding.ivUserBlackDot.isGone = true
+    }
+
+    fun setCartCountIcon(count: Int) {
+        if (currentMode == 0x00)
+            with(binding.tvCartCount) {
+                this.isVisible = count > 0
+                this.text = count.toString()
+            }
+    }
+
+    fun setAppBarTitle(title: String) {
+        binding.tvTitle.text = title
+    }
+
+    fun getCurrentMode(): Int = currentMode
+
+    private fun createCallBackFunc(callBackStr: String): () -> Unit {
+        val decoded = Base64.decode(callBackStr, Base64.DEFAULT)
+
+        return ObjectInputStream(ByteArrayInputStream(decoded))
+            .readObject() as (() -> Unit)
+    }
+}

--- a/app/src/main/java/com/woowa/banchan/ui/common/custom/CustomToolbar.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/custom/CustomToolbar.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.util.Base64
 import android.view.LayoutInflater
-import androidx.appcompat.widget.Toolbar
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isGone
 import androidx.core.view.isVisible

--- a/app/src/main/res/drawable/ic_dark_dot.xml
+++ b/app/src/main/res/drawable/ic_dark_dot.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/main" />
+            <corners android:radius="1000dp" />
+        </shape>
+    </item>
+    <item
+        android:bottom="2dp"
+        android:top="2dp"
+        android:right="2dp"
+        android:left="2dp"
+        android:gravity="center">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/black" />
+            <corners android:radius="1000dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/view_tool_bar_custom.xml
+++ b/app/src/main/res/layout/view_tool_bar_custom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/layout_toolbar"
+            android:layout_width="0dp"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/main"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_back"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="start"
+                android:layout_marginEnd="16dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:src="@drawable/ic_back"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/tv_title"
+                style="@style/appbarTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/toolbar_title" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_main_icons"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/iv_cart"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_margin="16dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:src="@drawable/ic_cart"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_cart_count"
+                    style="@style/normal_white_6"
+                    android:layout_width="14dp"
+                    android:layout_height="14dp"
+                    android:background="@drawable/ic_dark_dot"
+                    android:gravity="center"
+                    android:text="1"
+                    android:visibility="gone"
+                    app:layout_constraintEnd_toEndOf="@id/iv_cart"
+                    app:layout_constraintTop_toTopOf="@id/iv_cart" />
+
+                <ImageView
+                    android:id="@+id/iv_user"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="end"
+                    android:layout_margin="16dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:src="@drawable/ic_user"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/iv_cart"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
+                    android:id="@+id/iv_user_black_dot"
+                    android:layout_width="8.5dp"
+                    android:layout_height="8.5dp"
+                    android:src="@drawable/ic_dark_dot"
+                    android:visibility="gone"
+                    app:layout_constraintEnd_toEndOf="@id/iv_user"
+                    app:layout_constraintTop_toTopOf="@id/iv_user" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <ImageView
+                android:id="@+id/iv_refresh"
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:layout_gravity="end"
+                android:clickable="true"
+                android:focusable="true"
+                android:padding="16dp"
+                android:src="@drawable/ic_reload"
+                android:visibility="gone" />
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <declare-styleable name="CustomToolbar">
+        <attr name="toolbarTitle" format="string" />
+        <attr name="onBackClick" format="string" />
+        <attr name="onCartClick" format="string" />
+        <attr name="onUserClick" format="string" />
+        <attr name="onRefreshClick" format="string" />
+
+        <attr name="toolBarType">
+            <flag name="main" value="0x00" />
+            <flag name="sub" value="0x01" />
+            <flag name="sub_refresh" value="0x03" />
+        </attr>
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -3,10 +3,10 @@
 
     <declare-styleable name="CustomToolbar">
         <attr name="toolbarTitle" format="string" />
-        <attr name="onBackClick" format="string" />
-        <attr name="onCartClick" format="string" />
-        <attr name="onUserClick" format="string" />
-        <attr name="onRefreshClick" format="string" />
+        <attr name="onClickBackIcon" format="string" />
+        <attr name="onClickCartIcon" format="string" />
+        <attr name="onClickUserIcon" format="string" />
+        <attr name="onClickRefreshIcon" format="string" />
 
         <attr name="toolBarType">
             <flag name="main" value="0x00" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
     <style name="button">
         <item name="android:textSize">18sp</item>
         <item name="android:textColor">@color/white</item>
@@ -79,6 +80,9 @@
         <item name="android:textColor">@color/greyscale_default</item>
     </style>
 
-
+    <style name="normal_white_6">
+        <item name="android:textSize">6sp</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
 
 </resources>


### PR DESCRIPTION
### ❗️ 이슈
- close #20 

### 📝 구현한 내용
- custom app bar ui 구성
- custom app bar 기능 구현
  - custom app bar 다음의 기능을 추가했다.
  - type
     - main: 카트와 프로필 아이콘이 보이는 상태
     - sub: 카트와 프로필 아이콘이 사리지고, 백버튼이 나타나는 상태
     - sub_refresh: sub에서 refresh 아이콘이 추가된 상태
  - 각 아이콘의 onClick함수 추가
  - 코드 외부에서 카트 개수, 프로필 상태 알림 아이콘을 동작할 수 있는 메소드 등을 추가

### ❓ 고민한 내용
- custom tool bar를 Toobar를 상속받을지에 대한 고민

기본적으로 이 뷰는 toolbar를 제공하기에 ToolBar를 상속받아 제공하고자 했다.   
하지만, toolbar에서 제공되는 기본적인 padding이 적용되기에 다음과 같이 표현된다.
![스크린샷 2022-08-10 16 15 21](https://user-images.githubusercontent.com/72387349/183839981-00ce5e43-1a7e-41f4-a091-1a35e63b9cf6.png)

내부적으로는 toolbar를 적용하고 있지만 외부적으로 사용되기 위해 custom view의 root view인 constraint layout을 상속받아 제공하기로 결정했다.
![스크린샷 2022-08-10 16 15 57](https://user-images.githubusercontent.com/72387349/183840119-fe41bf32-0031-4626-b351-298279f85152.png)

