### PR TITLE
ui: splash 화면 구성

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
             android:exported="false" />
         <activity
             android:name=".ui.home.HomeActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/LaunchTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeActivity.kt
@@ -18,6 +18,7 @@ class HomeActivity : AppCompatActivity() {
     private lateinit var binding: ActivityHomeBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        setTheme(R.style.Theme_Banchan)
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_home)
         initAdapter()

--- a/app/src/main/res/drawable/background_splash_screen.xml
+++ b/app/src/main/res/drawable/background_splash_screen.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@color/white" />
+
+    <item
+        android:drawable="@drawable/ic_user"
+        android:gravity="center" />
+
+</layer-list>

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Base application theme. -->
+
     <style name="Theme.Banchan" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/main</item>
@@ -14,8 +15,11 @@
         <!-- Customize your theme here. -->
     </style>
 
-    <!--Splash Screen-->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
-        <item name="android:windowBackground">@drawable/background_splash_screen</item>
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+
+        <item name="android:windowSplashScreenBackground">@color/black</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">@color/white</item>
+        <item name="android:windowSplashscreenContent">@drawable/ic_user</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_user</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Base application theme. -->
+
     <style name="Theme.Banchan" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/main</item>
@@ -16,6 +17,9 @@
 
     <!--Splash Screen-->
     <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
-        <item name="android:windowBackground">@drawable/background_splash_screen</item>
+
+        <item name="android:windowSplashScreenBackground">@android:color/transparent</item>
+        <item name="android:windowSplashscreenContent">@drawable/ic_user</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_user</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Base application theme. -->
     <style name="Theme.Banchan" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
@@ -10,7 +10,12 @@
         <item name="colorSecondaryVariant">@color/white</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+    </style>
+
+    <!--Splash Screen-->
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowBackground">@drawable/background_splash_screen</item>
     </style>
 </resources>


### PR DESCRIPTION
### ❗️ 이슈
- close #15 

### 📝 구현한 내용
- splash 화면 구현
- themes-31v를 통해 android 12 이후 버전도 대응
- 기존 themes.xml를 통해 android 11 이전 버전도 대응

### ❓ 고민한 내용
- 어떻게 android 12와 그 이전버전을 대응할 수 있을까?
- 다음의 내용을 참고해 개발했다. -> [링크](https://medium.com/@radomir9720/android-splash-screen-easy-setup-for-both-11-version-and-lower-and-12-287ccb86f9c7)