### PR TITLE
feat: Best 화면 기능 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     implementation "androidx.activity:activity-ktx:$ktx_version"
     implementation "androidx.fragment:fragment-ktx:$ktx_version"
 
+    //Glide
+    implementation "com.github.bumptech.glide:glide:$glide_version"
+    annotationProcessor "com.github.bumptech.glide:compiler:$glide_version"
+
     //Retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Banchan"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".ui.order.OrderActivity"

--- a/app/src/main/java/com/woowa/banchan/data/remote/datasource/food/FoodDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/remote/datasource/food/FoodDataSourceImpl.kt
@@ -8,6 +8,7 @@ import javax.inject.Inject
 class FoodDataSourceImpl @Inject constructor(
     private val banchanService: BanchanService
 ) : FoodDataSource {
+    
     override suspend fun getBestFoods(): BestFood =
         banchanService.getBestFoods()
 

--- a/app/src/main/java/com/woowa/banchan/data/remote/datasource/food/FoodDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/remote/datasource/food/FoodDataSourceImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class FoodDataSourceImpl @Inject constructor(
     private val banchanService: BanchanService
 ) : FoodDataSource {
-    
+
     override suspend fun getBestFoods(): BestFood =
         banchanService.getBestFoods()
 

--- a/app/src/main/java/com/woowa/banchan/data/remote/dto/FoodItem.kt
+++ b/app/src/main/java/com/woowa/banchan/data/remote/dto/FoodItem.kt
@@ -17,7 +17,7 @@ data class FoodItem(
     @SerializedName("image")
     val image: String,
     @SerializedName("n_price")
-    val nPrice: String,
+    val nPrice: String?,
     @SerializedName("s_price")
     val sPrice: String,
     @SerializedName("title")

--- a/app/src/main/java/com/woowa/banchan/data/remote/repository/FoodRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/remote/repository/FoodRepositoryImpl.kt
@@ -9,9 +9,14 @@ import javax.inject.Inject
 class FoodRepositoryImpl @Inject constructor(
     private val foodDataSource: FoodDataSource
 ) : FoodRepository {
-    override suspend fun getBestFoods(): BestFood =
-        foodDataSource.getBestFoods()
 
-    override suspend fun getFoods(type: String): Food =
-        foodDataSource.getFoods(type)
+    override suspend fun getBestFoods(): Result<BestFood> =
+        runCatching {
+            foodDataSource.getBestFoods()
+        }
+
+    override suspend fun getFoods(type: String): Result<Food> =
+        runCatching {
+            foodDataSource.getFoods(type)
+        }
 }

--- a/app/src/main/java/com/woowa/banchan/domain/UiState.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/UiState.kt
@@ -1,0 +1,9 @@
+package com.woowa.banchan.domain
+
+sealed class UiState {
+
+    object Loading : UiState()
+    object Empty : UiState()
+    data class Success(val data: Any) : UiState()
+    data class Error(val message: String?) : UiState()
+}

--- a/app/src/main/java/com/woowa/banchan/domain/repository/FoodRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/FoodRepository.kt
@@ -5,7 +5,7 @@ import com.woowa.banchan.data.remote.dto.Food
 
 interface FoodRepository {
 
-    suspend fun getBestFoods(): BestFood
+    suspend fun getBestFoods(): Result<BestFood>
 
-    suspend fun getFoods(type: String): Food
+    suspend fun getFoods(type: String): Result<Food>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
@@ -1,16 +1,28 @@
 package com.woowa.banchan.domain.usecase.food
 
-import com.woowa.banchan.data.remote.dto.BestFood
+import com.woowa.banchan.domain.UiState
 import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class GetBestFoodsUseCaseImpl @Inject constructor(
     private val foodRepository: FoodRepository
 ) : GetBestFoodsUseCase {
 
-    override suspend operator fun invoke(): Result<BestFood> =
-        runCatching {
-            foodRepository.getBestFoods()
+    override suspend operator fun invoke(): Flow<UiState> =
+        withContext(Dispatchers.IO){
+            return@withContext flow {
+                emit(UiState.Loading)
+                foodRepository.getBestFoods().onSuccess {
+                    emit(UiState.Success(it))
+                }.onFailure {
+                    emit(UiState.Error(it.message))
+                }
+            }
         }
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
@@ -1,6 +1,6 @@
 package com.woowa.banchan.domain.usecase.food
 
-import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
@@ -5,7 +5,6 @@ import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -15,7 +14,7 @@ class GetBestFoodsUseCaseImpl @Inject constructor(
 ) : GetBestFoodsUseCase {
 
     override suspend operator fun invoke(): Flow<UiState> =
-        withContext(Dispatchers.IO){
+        withContext(Dispatchers.IO) {
             return@withContext flow {
                 emit(UiState.Loading)
                 foodRepository.getBestFoods().onSuccess {

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
@@ -1,6 +1,6 @@
 package com.woowa.banchan.domain.usecase.food
 
-import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetFoodsUseCase
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
@@ -1,15 +1,28 @@
 package com.woowa.banchan.domain.usecase.food
 
 import com.woowa.banchan.data.remote.dto.Food
+import com.woowa.banchan.domain.UiState
 import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetFoodsUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class GetFoodsUseCaseImpl @Inject constructor(
     private val foodRepository: FoodRepository
 ) : GetFoodsUseCase {
-    override suspend operator fun invoke(type: String): Result<Food> =
-        runCatching {
-            foodRepository.getFoods(type)
+
+    override suspend operator fun invoke(type: String): Flow<UiState> =
+        withContext(Dispatchers.IO){
+            return@withContext flow {
+                emit(UiState.Loading)
+                foodRepository.getFoods(type).onSuccess {
+                    emit(UiState.Success(it))
+                }.onFailure {
+                    emit(UiState.Error(it.message))
+                }
+            }
         }
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.domain.usecase.food
 
-import com.woowa.banchan.data.remote.dto.Food
 import com.woowa.banchan.domain.UiState
 import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetFoodsUseCase
@@ -15,7 +14,7 @@ class GetFoodsUseCaseImpl @Inject constructor(
 ) : GetFoodsUseCase {
 
     override suspend operator fun invoke(type: String): Flow<UiState> =
-        withContext(Dispatchers.IO){
+        withContext(Dispatchers.IO) {
             return@withContext flow {
                 emit(UiState.Loading)
                 foodRepository.getFoods(type).onSuccess {

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
@@ -1,7 +1,10 @@
 package com.woowa.banchan.domain.usecase.food.inter
 
 import com.woowa.banchan.data.remote.dto.BestFood
+import com.woowa.banchan.domain.UiState
+import kotlinx.coroutines.flow.Flow
 
 interface GetBestFoodsUseCase {
-    suspend operator fun invoke(): Result<BestFood>
+
+    suspend operator fun invoke(): Flow<UiState>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.domain.usecase.food.inter
 
-import com.woowa.banchan.data.remote.dto.BestFood
 import com.woowa.banchan.domain.UiState
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
@@ -1,6 +1,6 @@
 package com.woowa.banchan.domain.usecase.food.inter
 
-import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
 interface GetBestFoodsUseCase {

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetFoodsUseCase.kt
@@ -1,7 +1,9 @@
 package com.woowa.banchan.domain.usecase.food.inter
 
-import com.woowa.banchan.data.remote.dto.Food
+import com.woowa.banchan.domain.UiState
+import kotlinx.coroutines.flow.Flow
 
 interface GetFoodsUseCase {
-    suspend operator fun invoke(type: String): Result<Food>
+
+    suspend operator fun invoke(type: String): Flow<UiState>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetFoodsUseCase.kt
@@ -1,6 +1,6 @@
 package com.woowa.banchan.domain.usecase.food.inter
 
-import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
 interface GetFoodsUseCase {

--- a/app/src/main/java/com/woowa/banchan/ui/common/uistate/UiState.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/uistate/UiState.kt
@@ -1,4 +1,4 @@
-package com.woowa.banchan.domain
+package com.woowa.banchan.ui.common.uistate
 
 sealed class UiState {
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeActivity.kt
@@ -12,7 +12,9 @@ import com.woowa.banchan.ui.home.best.BestFragment
 import com.woowa.banchan.ui.home.main.MainFragment
 import com.woowa.banchan.ui.home.side.SideFragment
 import com.woowa.banchan.ui.home.soup.SoupFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class HomeActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityHomeBinding

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeItemAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeItemAdapter.kt
@@ -2,12 +2,13 @@ package com.woowa.banchan.ui.home
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.data.remote.dto.FoodItem
 import com.woowa.banchan.databinding.ItemHomeBinding
 
-class HomeItemAdapter(private val categoryFood: List<FoodItem>) :
-    RecyclerView.Adapter<BestItemViewHolder>() {
+class HomeItemAdapter : ListAdapter<FoodItem, BestItemViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BestItemViewHolder {
         return BestItemViewHolder(
@@ -20,14 +21,26 @@ class HomeItemAdapter(private val categoryFood: List<FoodItem>) :
     }
 
     override fun onBindViewHolder(holder: BestItemViewHolder, position: Int) {
-        holder.bind(categoryFood[position])
+        holder.bind(getItem(position))
     }
 
-    override fun getItemCount(): Int = categoryFood.size
+
+    companion object {
+
+        val diffUtil = object : DiffUtil.ItemCallback<FoodItem>() {
+            override fun areItemsTheSame(oldItem: FoodItem, newItem: FoodItem): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: FoodItem, newItem: FoodItem): Boolean {
+                return oldItem.detailHash == newItem.detailHash
+            }
+        }
+    }
 }
 
-class BestItemViewHolder(private val binding: ItemHomeBinding) :
-    RecyclerView.ViewHolder(binding.root) {
+class BestItemViewHolder(private val binding: ItemHomeBinding) : RecyclerView.ViewHolder(binding.root) {
+
     fun bind(food: FoodItem) {
         binding.food = food
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestAdapter.kt
@@ -2,9 +2,10 @@ package com.woowa.banchan.ui.home.best
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.R
-import com.woowa.banchan.data.remote.dto.BestFood
 import com.woowa.banchan.data.remote.dto.BestFoodCategory
 import com.woowa.banchan.data.remote.dto.FoodItem
 import com.woowa.banchan.databinding.ItemBestHeaderBinding
@@ -12,9 +13,7 @@ import com.woowa.banchan.databinding.ItemBestRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.ui.home.HomeItemAdapter
 
-class BestAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-
-    var bestFood = BestFood(emptyList(), 0)
+class BestAdapter : ListAdapter<BestFoodCategory,RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
@@ -45,13 +44,13 @@ class BestAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
             HOME_HEADER -> (holder as HomeHeaderViewHolder).bind()
-            BEST_HEADER -> (holder as BestHeaderViewHolder).bind(bestFood.body[position / 2])
-            else -> (holder as BestRecyclerViewViewHolder).bind(bestFood.body[position / 2 - 1].items)
+            BEST_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position / 2))
+            else -> (holder as BestRecyclerViewViewHolder).bind(getItem(position / 2 - 1).items)
         }
     }
 
     override fun getItemCount(): Int {
-        return bestFood.body.size * 2 + 1
+        return currentList.size * 2 + 1
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -69,6 +68,16 @@ class BestAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         const val HOME_HEADER = 1
         const val BEST_HEADER = 2
         const val BEST = 3
+
+        val diffUtil = object : DiffUtil.ItemCallback<BestFoodCategory>() {
+            override fun areItemsTheSame(oldItem: BestFoodCategory, newItem: BestFoodCategory): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: BestFoodCategory, newItem: BestFoodCategory): Boolean {
+                return oldItem.categoryId == newItem.categoryId
+            }
+        }
     }
 }
 
@@ -89,6 +98,8 @@ class BestHeaderViewHolder(private val binding: ItemBestHeaderBinding) :
 class BestRecyclerViewViewHolder(private val binding: ItemBestRecyclerviewBinding) :
     RecyclerView.ViewHolder(binding.root) {
     fun bind(categoryFood: List<FoodItem>) {
-        binding.layoutBest.adapter = HomeItemAdapter(categoryFood)
+        val adapter = HomeItemAdapter()
+        adapter.submitList(categoryFood)
+        binding.layoutBest.adapter = adapter
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestAdapter.kt
@@ -44,13 +44,9 @@ class BestAdapter : ListAdapter<BestFoodCategory,RecyclerView.ViewHolder>(diffUt
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
             HOME_HEADER -> (holder as HomeHeaderViewHolder).bind()
-            BEST_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position / 2))
-            else -> (holder as BestRecyclerViewViewHolder).bind(getItem(position / 2 - 1).items)
+            BEST_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position))
+            else -> (holder as BestRecyclerViewViewHolder).bind(getItem(position).items)
         }
-    }
-
-    override fun getItemCount(): Int {
-        return currentList.size * 2 + 1
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -62,6 +58,16 @@ class BestAdapter : ListAdapter<BestFoodCategory,RecyclerView.ViewHolder>(diffUt
             else
                 BEST
         }
+    }
+
+    fun submitHeaderList(list: List<BestFoodCategory>) {
+        val newList = mutableListOf<BestFoodCategory?>()
+        newList.add(null)
+        for(category in list) {
+            newList.add(category)
+            newList.add(category)
+        }
+        submitList(newList)
     }
 
     companion object {

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestAdapter.kt
@@ -13,7 +13,7 @@ import com.woowa.banchan.databinding.ItemBestRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.ui.home.HomeItemAdapter
 
-class BestAdapter : ListAdapter<BestFoodCategory,RecyclerView.ViewHolder>(diffUtil) {
+class BestAdapter : ListAdapter<BestFoodCategory, RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
@@ -63,7 +63,7 @@ class BestAdapter : ListAdapter<BestFoodCategory,RecyclerView.ViewHolder>(diffUt
     fun submitHeaderList(list: List<BestFoodCategory>) {
         val newList = mutableListOf<BestFoodCategory?>()
         newList.add(null)
-        for(category in list) {
+        for (category in list) {
             newList.add(category)
             newList.add(category)
         }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
@@ -1,7 +1,6 @@
 package com.woowa.banchan.ui.home.best
 
 import android.graphics.Paint
-import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -10,11 +9,10 @@ import com.bumptech.glide.Glide
 
 @BindingAdapter("nPricePercent", "sPricePercent")
 fun TextView.setPercent(nPrice: String?, sPrice: String) {
-    if(nPrice == null) {
+    if (nPrice == null) {
         text = ""
         visibility = View.GONE
-    }
-    else {
+    } else {
         val originPrice = nPrice.replace("원", "").replace(",", "").toLong()
         val salePrice = sPrice.replace("원", "").replace(",", "").toLong()
         val percent = (((originPrice - salePrice) * 100) / originPrice)
@@ -25,7 +23,7 @@ fun TextView.setPercent(nPrice: String?, sPrice: String) {
 @BindingAdapter("nPrice", "sPrice")
 fun TextView.setOriginPrice(nPrice: String?, sPrice: String) {
     paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
-    if(nPrice == null)
+    if (nPrice == null)
         text = ""
     else
         text = sPrice

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
@@ -2,6 +2,7 @@ package com.woowa.banchan.ui.home.best
 
 import android.graphics.Paint
 import android.util.Log
+import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
@@ -11,6 +12,7 @@ import com.bumptech.glide.Glide
 fun TextView.setPercent(nPrice: String?, sPrice: String) {
     if(nPrice == null) {
         text = ""
+        visibility = View.GONE
     }
     else {
         val originPrice = nPrice.replace("원", "").replace(",", "").toLong()

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
@@ -1,8 +1,11 @@
 package com.woowa.banchan.ui.home.best
 
 import android.graphics.Paint
+import android.util.Log
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
 
 @BindingAdapter("nPricePercent", "sPricePercent")
 fun TextView.setPercent(nPrice: String?, sPrice: String) {
@@ -12,7 +15,7 @@ fun TextView.setPercent(nPrice: String?, sPrice: String) {
     else {
         val originPrice = nPrice.replace("원", "").replace(",", "").toLong()
         val salePrice = sPrice.replace("원", "").replace(",", "").toLong()
-        val percent = ((originPrice - salePrice) / originPrice) * 100
+        val percent = (((originPrice - salePrice) * 100) / originPrice)
         text = "$percent%"
     }
 }
@@ -24,4 +27,11 @@ fun TextView.setOriginPrice(nPrice: String?, sPrice: String) {
         text = ""
     else
         text = sPrice
+}
+
+@BindingAdapter("image")
+fun ImageView.setImage(url: String) {
+    Glide.with(context)
+        .load(url)
+        .into(this)
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
@@ -26,7 +26,7 @@ fun TextView.setOriginPrice(nPrice: String?, sPrice: String) {
     if (nPrice == null)
         text = ""
     else
-        text = sPrice
+        text = nPrice
 }
 
 @BindingAdapter("image")

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestBindingAdapter.kt
@@ -4,16 +4,24 @@ import android.graphics.Paint
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 
-@BindingAdapter("nPrice", "sPrice")
-fun TextView.setPercent(nPrice: String, sPrice: String) {
-    val originPrice = nPrice.replace("원", "").replace(",", "").toLong()
-    val salePrice = sPrice.replace("원", "").replace(",", "").toLong()
-    val percent = ((originPrice - salePrice) / originPrice) * 100
-    text = "$percent%"
+@BindingAdapter("nPricePercent", "sPricePercent")
+fun TextView.setPercent(nPrice: String?, sPrice: String) {
+    if(nPrice == null) {
+        text = ""
+    }
+    else {
+        val originPrice = nPrice.replace("원", "").replace(",", "").toLong()
+        val salePrice = sPrice.replace("원", "").replace(",", "").toLong()
+        val percent = ((originPrice - salePrice) / originPrice) * 100
+        text = "$percent%"
+    }
 }
 
-@BindingAdapter("originPrice")
-fun TextView.setOriginPrice(originPrice: String) {
+@BindingAdapter("nPrice", "sPrice")
+fun TextView.setOriginPrice(nPrice: String?, sPrice: String) {
     paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
-    text = originPrice
+    if(nPrice == null)
+        text = ""
+    else
+        text = sPrice
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -6,11 +6,17 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentBestBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class BestFragment : Fragment() {
+
     private lateinit var binding: FragmentBestBinding
+
+    private val viewModel: BestViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -18,6 +24,10 @@ class BestFragment : Fragment() {
     ): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_best, container, false)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
     }
 
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.data.remote.dto.BestFood
+import com.woowa.banchan.data.remote.dto.BestFoodCategory
 import com.woowa.banchan.databinding.FragmentBestBinding
 import com.woowa.banchan.domain.UiState
 import com.woowa.banchan.utils.showToast
@@ -56,8 +57,7 @@ class BestFragment : Fragment() {
         viewModel.bestUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if(state is UiState.Success) {
-                    bestAdapter.bestFood = state.data as BestFood
-                    bestAdapter.notifyDataSetChanged()
+                    bestAdapter.submitList((state.data as BestFood).body)
                 } else if(state is UiState.Error) {
                     showToast(state.message)
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.data.remote.dto.BestFood
 import com.woowa.banchan.databinding.FragmentBestBinding
-import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.utils.showToast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -13,6 +13,7 @@ import com.woowa.banchan.R
 import com.woowa.banchan.data.remote.dto.BestFood
 import com.woowa.banchan.databinding.FragmentBestBinding
 import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.utils.showToast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -57,6 +58,8 @@ class BestFragment : Fragment() {
                 if(state is UiState.Success) {
                     bestAdapter.bestFood = state.data as BestFood
                     bestAdapter.notifyDataSetChanged()
+                } else if(state is UiState.Error) {
+                    showToast(state.message)
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -1,6 +1,7 @@
 package com.woowa.banchan.ui.home.best
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -57,7 +58,7 @@ class BestFragment : Fragment() {
         viewModel.bestUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if(state is UiState.Success) {
-                    bestAdapter.submitList((state.data as BestFood).body)
+                    bestAdapter.submitHeaderList((state.data as BestFood).body)
                 } else if(state is UiState.Error) {
                     showToast(state.message)
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -7,9 +7,15 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
+import com.woowa.banchan.data.remote.dto.BestFood
 import com.woowa.banchan.databinding.FragmentBestBinding
+import com.woowa.banchan.domain.UiState
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class BestFragment : Fragment() {
@@ -17,6 +23,10 @@ class BestFragment : Fragment() {
     private lateinit var binding: FragmentBestBinding
 
     private val viewModel: BestViewModel by viewModels()
+
+    private val bestAdapter: BestAdapter by lazy {
+        BestAdapter()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -28,6 +38,27 @@ class BestFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initAdapter()
+        initViews()
+        initObserve()
+    }
+
+    private fun initAdapter() {
+        binding.layoutBest.adapter = bestAdapter
+    }
+
+    private fun initViews() {
+        viewModel.getBestFoods()
+    }
+
+    private fun initObserve() {
+        viewModel.bestUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach { state ->
+                if(state is UiState.Success) {
+                    bestAdapter.bestFood = state.data as BestFood
+                    bestAdapter.notifyDataSetChanged()
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -1,7 +1,6 @@
 package com.woowa.banchan.ui.home.best
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,7 +11,6 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.data.remote.dto.BestFood
-import com.woowa.banchan.data.remote.dto.BestFoodCategory
 import com.woowa.banchan.databinding.FragmentBestBinding
 import com.woowa.banchan.domain.UiState
 import com.woowa.banchan.utils.showToast
@@ -57,9 +55,9 @@ class BestFragment : Fragment() {
     private fun initObserve() {
         viewModel.bestUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
-                if(state is UiState.Success) {
+                if (state is UiState.Success) {
                     bestAdapter.submitHeaderList((state.data as BestFood).body)
-                } else if(state is UiState.Error) {
+                } else if (state is UiState.Error) {
                     showToast(state.message)
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.ui.home.best
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woowa.banchan.domain.UiState
@@ -17,13 +16,13 @@ class BestViewModel @Inject constructor(
     private val getBestFoodsUseCase: GetBestFoodsUseCase
 ) : ViewModel() {
 
-    private var _best = MutableStateFlow<UiState>(UiState.Empty)
-    val best: StateFlow<UiState> get() = _best.asStateFlow()
+    private var _bestUiState = MutableStateFlow<UiState>(UiState.Empty)
+    val bestUiState: StateFlow<UiState> get() = _bestUiState.asStateFlow()
 
     fun getBestFoods() {
         viewModelScope.launch {
             getBestFoodsUseCase().collect { uiState ->
-                _best.emit(uiState)
+                _bestUiState.emit(uiState)
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
@@ -1,0 +1,30 @@
+package com.woowa.banchan.ui.home.best
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BestViewModel @Inject constructor(
+    private val getBestFoodsUseCase: GetBestFoodsUseCase
+) : ViewModel() {
+
+    private var _best = MutableStateFlow<UiState>(UiState.Empty)
+    val best: StateFlow<UiState> get() = _best.asStateFlow()
+
+    fun getBestFoods() {
+        viewModelScope.launch {
+            getBestFoodsUseCase().collect { uiState ->
+                _best.emit(uiState)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
@@ -2,7 +2,7 @@ package com.woowa.banchan.ui.home.best
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woowa.banchan.domain.UiState
+import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/woowa/banchan/utils/Toast.kt
+++ b/app/src/main/java/com/woowa/banchan/utils/Toast.kt
@@ -4,5 +4,5 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 
 fun Fragment.showToast(message: String?) {
-    Toast.makeText(context,message ?: "에러가 발생하였습니다.",Toast.LENGTH_SHORT).show()
+    Toast.makeText(context, message ?: "에러가 발생하였습니다.", Toast.LENGTH_SHORT).show()
 }

--- a/app/src/main/java/com/woowa/banchan/utils/Toast.kt
+++ b/app/src/main/java/com/woowa/banchan/utils/Toast.kt
@@ -1,0 +1,8 @@
+package com.woowa.banchan.utils
+
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+
+fun Fragment.showToast(message: String?) {
+    Toast.makeText(context,message ?: "에러가 발생하였습니다.",Toast.LENGTH_SHORT).show()
+}

--- a/app/src/main/res/layout/fragment_best.xml
+++ b/app/src/main/res/layout/fragment_best.xml
@@ -11,7 +11,6 @@
         android:id="@+id/layout_best"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingHorizontal="16dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:context=".ui.home.best.BestFragment" />
 </layout>

--- a/app/src/main/res/layout/item_best_header.xml
+++ b/app/src/main/res/layout/item_best_header.xml
@@ -18,6 +18,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingTop="24dp"
+            android:paddingHorizontal="16dp"
             android:text="@{beestFoodCategory.name}"
             tools:text="풍성한 고기반찬" />
 

--- a/app/src/main/res/layout/item_best_recyclerview.xml
+++ b/app/src/main/res/layout/item_best_recyclerview.xml
@@ -12,6 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:paddingHorizontal="16dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:listitem="@layout/item_home"
         tools:context=".ui.home.best.BestFragment" />

--- a/app/src/main/res/layout/item_home.xml
+++ b/app/src/main/res/layout/item_home.xml
@@ -68,8 +68,8 @@
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_content"
-            app:nPrice="@{food.nPrice}"
-            app:sPrice="@{food.sPrice}"
+            app:nPricePercent="@{food.nPrice}"
+            app:sPricePercent="@{food.sPrice}"
             tools:text="20%" />
 
         <TextView
@@ -94,7 +94,8 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_percent"
-            app:originPrice="@{food.nPrice}"
+            app:nPrice="@{food.nPrice}"
+            app:sPrice="@{food.sPrice}"
             tools:text="15,800원" />
 
 

--- a/app/src/main/res/layout/item_home.xml
+++ b/app/src/main/res/layout/item_home.xml
@@ -67,6 +67,7 @@
             style="@style/percent_14"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:paddingEnd="4dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_content"
             app:nPricePercent="@{food.nPrice}"
@@ -78,12 +79,10 @@
             style="@style/normal_14"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:paddingStart="4dp"
             android:text="@{food.sPrice}"
-            app:layout_constraintBottom_toBottomOf="@id/tv_percent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_percent"
-            app:layout_constraintTop_toTopOf="@id/tv_percent"
+            app:layout_constraintTop_toBottomOf="@id/tv_content"
             tools:text="12,640원" />
 
         <TextView

--- a/app/src/main/res/layout/item_home.xml
+++ b/app/src/main/res/layout/item_home.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="food"
             type="com.woowa.banchan.data.remote.dto.FoodItem" />
@@ -21,7 +22,7 @@
             android:layout_height="168dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:background="@color/main" />
+            app:image="@{food.image}"/>
 
         <ImageView
             android:id="@+id/iv_cart"
@@ -79,10 +80,10 @@
             android:layout_height="wrap_content"
             android:paddingStart="4dp"
             android:text="@{food.sPrice}"
-            app:layout_constraintStart_toEndOf="@id/tv_percent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_percent"
             app:layout_constraintBottom_toBottomOf="@id/tv_percent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_percent"
+            app:layout_constraintTop_toTopOf="@id/tv_percent"
             tools:text="12,640원" />
 
         <TextView
@@ -91,8 +92,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingTop="8dp"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_percent"
             app:nPrice="@{food.nPrice}"
             app:sPrice="@{food.sPrice}"

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         room_version = "2.4.3"
         retrofit_version = "2.9.0"
         okhttp_version = "4.10.0"
+        glide_version = '4.13.2'
 
         junit = '4.13.2'
         androidx_junit = '1.1.3'


### PR DESCRIPTION
### ❗️ 이슈
- close #25 

### 📝 구현한 내용
- Banchan Api를 통해 BestFood 데이터를 받아온다.
- 이미지를 띄워주기 위해 Glide를 build gradle에 추가한다.
- 데이터를 RecyclerView에 띄워준다.

### ❓ 고민한 내용
RecyclerView.Adapter -> ListAdapter로 마이그레이션 하였습니다.

`ListAdapter`의 `submitList`는 비동기적으로 처리되기 때문에
앱에 처음 진입시 스크롤이 맨 위가 아닌 중간으로 가 있는 버그가 생겼습니다.

저는 처음에 아래와 같이 정의하였습니다.
``` kotlin
override fun getItemCount(): Int {
        return currentList.size * 2 + 1
}
```

<img width="364" alt="스크린샷 2022-08-10 오후 11 57 59" src="https://user-images.githubusercontent.com/77563227/183937804-5b9371cb-7b7a-43bb-8cca-2d2f9ee9b715.png">

그 이유는 아래와 같습니다.

- FoodCategory 하나당 2개의 아이템이 필요 (2,3번) -> size * 2
- 최상단 헤더는 고정 (1번) -> size +1

하지만 1번 헤더는 data를 받아와서 처리하는 방식이 아니기 때문에 바로 로드가 되었고,
나머지 2,3번 아이템은 비동기적으로 처리되기 때문에 나중에 로드 되었습니다.

그러다보니 앱을 처음 실행했을 때
아래와 같이 헤더가 아니라 아이템이 먼저 보이는 현상이 발생하였습니다.
(스크롤해서 위로 올리면 헤더는 정상적으로 나타나 있습니다.)

<img width="367" alt="image" src="https://user-images.githubusercontent.com/77563227/183939087-aad8ae42-8ba0-4956-89c7-5b521fd046f5.png">

``` kotlin
fun submitHeaderList(list: List<BestFoodCategory>) {

    val newList = mutableListOf<BestFoodCategory?>()

    newList.add(null) //1번 헤더

    for (category in list) {
        newList.add(category) //2번 아이템
        newList.add(category) //3번 아이템
    }
    submitList(newList)
}
```
그래서 
itemCount를 상속받아 itemSize를 인위적으로 늘리는 것이 아닌,
직접 list에 새로운 아이템을 넣는 방식으로 수정하여 문제를 해결하였습니다.