### PR TITLE
refactor: uiState 제네릭 변환

### DIFF
--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetBestFoodsUseCaseImpl.kt
@@ -1,5 +1,7 @@
 package com.woowa.banchan.domain.usecase.food
 
+import com.woowa.banchan.data.remote.dto.BestFood
+import com.woowa.banchan.data.remote.dto.FoodItem
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
@@ -13,7 +15,7 @@ class GetBestFoodsUseCaseImpl @Inject constructor(
     private val foodRepository: FoodRepository
 ) : GetBestFoodsUseCase {
 
-    override suspend operator fun invoke(): Flow<UiState> =
+    override suspend operator fun invoke(): Flow<UiState<BestFood>> =
         withContext(Dispatchers.IO) {
             return@withContext flow {
                 emit(UiState.Loading)

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/GetFoodsUseCaseImpl.kt
@@ -1,8 +1,9 @@
 package com.woowa.banchan.domain.usecase.food
 
-import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.data.remote.dto.Food
 import com.woowa.banchan.domain.repository.FoodRepository
 import com.woowa.banchan.domain.usecase.food.inter.GetFoodsUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -13,7 +14,7 @@ class GetFoodsUseCaseImpl @Inject constructor(
     private val foodRepository: FoodRepository
 ) : GetFoodsUseCase {
 
-    override suspend operator fun invoke(type: String): Flow<UiState> =
+    override suspend operator fun invoke(type: String): Flow<UiState<Food>> =
         withContext(Dispatchers.IO) {
             return@withContext flow {
                 emit(UiState.Loading)

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetBestFoodsUseCase.kt
@@ -1,9 +1,10 @@
 package com.woowa.banchan.domain.usecase.food.inter
 
+import com.woowa.banchan.data.remote.dto.BestFood
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
 interface GetBestFoodsUseCase {
 
-    suspend operator fun invoke(): Flow<UiState>
+    suspend operator fun invoke(): Flow<UiState<BestFood>>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/food/inter/GetFoodsUseCase.kt
@@ -1,9 +1,10 @@
 package com.woowa.banchan.domain.usecase.food.inter
 
+import com.woowa.banchan.data.remote.dto.Food
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
 interface GetFoodsUseCase {
 
-    suspend operator fun invoke(type: String): Flow<UiState>
+    suspend operator fun invoke(type: String): Flow<UiState<Food>>
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/uistate/UiState.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/uistate/UiState.kt
@@ -1,9 +1,9 @@
 package com.woowa.banchan.ui.common.uistate
 
-sealed class UiState {
+sealed class UiState<out T : Any> {
 
-    object Loading : UiState()
-    object Empty : UiState()
-    data class Success(val data: Any) : UiState()
-    data class Error(val message: String?) : UiState()
+    object Loading : UiState<Nothing>()
+    object Empty : UiState<Nothing>()
+    data class Success<out T : Any>(val data: T) : UiState<T>()
+    data class Error(val message: String?) : UiState<Nothing>()
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -56,7 +56,7 @@ class BestFragment : Fragment() {
         viewModel.bestUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if (state is UiState.Success) {
-                    bestAdapter.submitHeaderList((state.data as BestFood).body)
+                    bestAdapter.submitHeaderList((state.data).body)
                 } else if (state is UiState.Error) {
                     showToast(state.message)
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestViewModel.kt
@@ -2,8 +2,9 @@ package com.woowa.banchan.ui.home.best
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.data.remote.dto.BestFood
 import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,8 +17,8 @@ class BestViewModel @Inject constructor(
     private val getBestFoodsUseCase: GetBestFoodsUseCase
 ) : ViewModel() {
 
-    private var _bestUiState = MutableStateFlow<UiState>(UiState.Empty)
-    val bestUiState: StateFlow<UiState> get() = _bestUiState.asStateFlow()
+    private var _bestUiState = MutableStateFlow<UiState<BestFood>>(UiState.Empty)
+    val bestUiState: StateFlow<UiState<BestFood>> get() = _bestUiState.asStateFlow()
 
     fun getBestFoods() {
         viewModelScope.launch {


### PR DESCRIPTION
### ❗️ 이슈
- close #28

### 📝 구현한 내용
- uiState를 제네릭 타입으로 변환한다.
- 이는 다음의 이유를 가짐
   - view에서 데이터를 타입캐스팅 과정에서 실패할 수 있다.
   - 이는 ui layer에서 하는 작업이 아니라고 판단
   - 따라서, 제네릭 타입으로 변환해 flow 상에서 타입을 그대로 전달 받기를 수행함