### PR TITLE
feat: order detail 화면 구현하기

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
             android:name=".ui.order.OrderActivity"
             android:exported="false" />
         <activity
+            android:name=".ui.order.detail.OrderDetailActivity"
+            android:exported="false" />
+        <activity
             android:name=".ui.cart.CartActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/woowa/banchan/data/local/dao/OrderItemDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/OrderItemDao.kt
@@ -1,6 +1,21 @@
 package com.woowa.banchan.data.local.dao
 
-import androidx.room.Dao
+import androidx.room.*
+import com.woowa.banchan.data.local.BanchanDataBase.Companion.orderItemTable
+import com.woowa.banchan.data.local.entity.OrderItemDto
 
 @Dao
-interface OrderItemDao
+interface OrderItemDao {
+
+    @Insert
+    fun insert(orderItemDto: OrderItemDto)
+
+    @Update
+    fun update(orderItemDto: OrderItemDto)
+
+    @Delete
+    fun delete(orderItemDto: OrderItemDto)
+
+    @Query("SELECT * FROM $orderItemTable WHERE order_id = :orderId")
+    fun getOrderDetail(orderId: Long): List<OrderItemDto>
+}

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSource.kt
@@ -1,8 +1,10 @@
 package com.woowa.banchan.data.local.datasource.order
 
 import com.woowa.banchan.data.local.entity.OrderDto
+import com.woowa.banchan.data.local.entity.OrderItemDto
 
 interface OrderDataSource {
 
     suspend fun getTotalOrderList(): Result<List<OrderDto>>
+    suspend fun getOrderDetail(orderId: Long): Result<List<OrderItemDto>>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSourceImpl.kt
@@ -1,13 +1,20 @@
 package com.woowa.banchan.data.local.datasource.order
 
 import com.woowa.banchan.data.local.dao.OrderDao
+import com.woowa.banchan.data.local.dao.OrderItemDao
 import com.woowa.banchan.data.local.entity.OrderDto
+import com.woowa.banchan.data.local.entity.OrderItemDto
 import javax.inject.Inject
 
 class OrderDataSourceImpl @Inject constructor(
-    private val orderDao: OrderDao
+    private val orderDao: OrderDao,
+    private val orderItemDao: OrderItemDao
 ) : OrderDataSource {
 
     override suspend fun getTotalOrderList(): Result<List<OrderDto>> =
         runCatching { orderDao.getTotalOrderList() }
+
+    override suspend fun getOrderDetail(orderId: Long): Result<List<OrderItemDto>> =
+        runCatching { orderItemDao.getOrderDetail(orderId) }
+
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderItemDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderItemDto.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.woowa.banchan.data.local.BanchanDataBase.Companion.orderItemTable
+import com.woowa.banchan.domain.model.OrderItem
 
 @Entity(tableName = orderItemTable)
 data class OrderItemDto(
@@ -14,3 +15,14 @@ data class OrderItemDto(
     @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "image_url") val imageUrl: String,
 )
+
+fun OrderItemDto.toOrderItem(): OrderItem {
+    return OrderItem(
+        id = id,
+        orderId = orderId,
+        count = count,
+        price = price,
+        title = title,
+        imageUrl = imageUrl
+    )
+}

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
@@ -2,7 +2,9 @@ package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.order.OrderDataSource
 import com.woowa.banchan.data.local.entity.toOrder
+import com.woowa.banchan.data.local.entity.toOrderItem
 import com.woowa.banchan.domain.model.Order
+import com.woowa.banchan.domain.model.OrderItem
 import com.woowa.banchan.domain.repository.OrderRepository
 import javax.inject.Inject
 
@@ -14,5 +16,11 @@ class OrderRepositoryImpl @Inject constructor(
         runCatching {
             val list = orderDataSource.getTotalOrderList().getOrThrow()
             list.map { it.toOrder() }
+        }
+
+    override suspend fun getOrderDetail(orderId: Long): Result<List<OrderItem>> =
+        runCatching {
+            val list = orderDataSource.getOrderDetail(orderId).getOrThrow()
+            list.map { it.toOrderItem() }
         }
 }

--- a/app/src/main/java/com/woowa/banchan/di/DataBaseModule.kt
+++ b/app/src/main/java/com/woowa/banchan/di/DataBaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.woowa.banchan.data.local.BanchanDataBase
 import com.woowa.banchan.data.local.dao.CartDao
 import com.woowa.banchan.data.local.dao.OrderDao
+import com.woowa.banchan.data.local.dao.OrderItemDao
 import com.woowa.banchan.data.local.dao.RecentDao
 import dagger.Module
 import dagger.Provides
@@ -35,5 +36,10 @@ object DataBaseModule {
     @Provides
     fun provideOrderDao(dataBase: BanchanDataBase): OrderDao {
         return dataBase.orderDao()
+    }
+
+    @Provides
+    fun provideOrderItemDao(dataBase: BanchanDataBase): OrderItemDao {
+        return dataBase.orderItemDao()
     }
 }

--- a/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
+++ b/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
@@ -6,7 +6,9 @@ import com.woowa.banchan.domain.usecase.food.GetBestFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.GetFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.inter.GetBestFoodsUseCase
 import com.woowa.banchan.domain.usecase.food.inter.GetFoodsUseCase
+import com.woowa.banchan.domain.usecase.order.GetOrderDetailUseCaseImpl
 import com.woowa.banchan.domain.usecase.order.GetTotalOrderUseCaseImpl
+import com.woowa.banchan.domain.usecase.order.inter.GetOrderDetailUseCase
 import com.woowa.banchan.domain.usecase.order.inter.GetTotalOrderUseCase
 import com.woowa.banchan.domain.usecase.recent.GetRecentlyViewedFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.recent.inter.GetRecentlyViewedFoodsUseCase
@@ -49,4 +51,10 @@ abstract class UseCaseModule {
     abstract fun provideGetTotalOrderUseCase(
         GetTotalOrderUseCaseImpl: GetTotalOrderUseCaseImpl
     ): GetTotalOrderUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideGetOrderDetailUseCase(
+        GetOrderDetailUseCaseImpl: GetOrderDetailUseCaseImpl
+    ): GetOrderDetailUseCase
 }

--- a/app/src/main/java/com/woowa/banchan/domain/model/OrderItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/OrderItem.kt
@@ -1,0 +1,10 @@
+package com.woowa.banchan.domain.model
+
+data class OrderItem(
+    val id: Long,
+    val orderId: Long,
+    val count: Int,
+    val price: Int,
+    val title: String,
+    val imageUrl: String,
+)

--- a/app/src/main/java/com/woowa/banchan/domain/repository/OrderRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/OrderRepository.kt
@@ -1,8 +1,10 @@
 package com.woowa.banchan.domain.repository
 
 import com.woowa.banchan.domain.model.Order
+import com.woowa.banchan.domain.model.OrderItem
 
 interface OrderRepository {
 
     suspend fun getTotalOrderList(): Result<List<Order>>
+    suspend fun getOrderDetail(orderId: Long): Result<List<OrderItem>>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/order/GetOrderDetailUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/order/GetOrderDetailUseCaseImpl.kt
@@ -1,0 +1,24 @@
+package com.woowa.banchan.domain.usecase.order
+
+import com.woowa.banchan.domain.model.OrderItem
+import com.woowa.banchan.domain.repository.OrderRepository
+import com.woowa.banchan.domain.usecase.order.inter.GetOrderDetailUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class GetOrderDetailUseCaseImpl @Inject constructor(
+    private val orderRepository: OrderRepository
+) : GetOrderDetailUseCase {
+
+    override suspend operator fun invoke(orderId: Long): Flow<UiState<List<OrderItem>>> =
+        flow {
+            emit(UiState.Loading)
+            orderRepository.getOrderDetail(orderId)
+                .onSuccess { emit(UiState.Success(it)) }
+                .onFailure { emit(UiState.Error(it.message)) }
+        }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/GetOrderDetailUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/GetOrderDetailUseCase.kt
@@ -1,3 +1,10 @@
 package com.woowa.banchan.domain.usecase.order.inter
 
-interface GetOrderDetailUseCase
+import com.woowa.banchan.domain.model.OrderItem
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.flow.Flow
+
+interface GetOrderDetailUseCase {
+
+    suspend operator fun invoke(orderId: Long): Flow<UiState<List<OrderItem>>>
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/GetTotalOrderUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/GetTotalOrderUseCase.kt
@@ -1,11 +1,10 @@
 package com.woowa.banchan.domain.usecase.order.inter
 
-import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
-interface GetTotalOrderUseCase{
+interface GetTotalOrderUseCase {
 
     suspend operator fun invoke(): Flow<UiState<List<Order>>>
 }

--- a/app/src/main/java/com/woowa/banchan/ui/order/OrderActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/OrderActivity.kt
@@ -35,7 +35,7 @@ class OrderActivity : AppCompatActivity() {
     private fun initAdapter() {
         orderRVAdapter = OrderRVAdapter {
             val intent = Intent(this, OrderDetailActivity::class.java)
-            intent.putExtra("id", it.id)
+            intent.putExtra("orderId", it.id)
             startActivity(intent)
         }
         binding.rvOrder.adapter = orderRVAdapter

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailActivity.kt
@@ -1,33 +1,56 @@
 package com.woowa.banchan.ui.order.detail
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.lifecycle.flowWithLifecycle
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.ActivityOrderDetailBinding
+import com.woowa.banchan.domain.model.Order
+import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.order.detail.adapter.OrderDetailRVAdapter
+import com.woowa.banchan.utils.showToast
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.onEach
 
+@AndroidEntryPoint
 class OrderDetailActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityOrderDetailBinding
+    private val viewModel by viewModels<OrderDetailViewModel>()
     private lateinit var orderDetailRVAdapter: OrderDetailRVAdapter
 
-    private val orderId: Int by lazy {
+    private val order: Order? by lazy {
         intent.getIntExtra("orderId", -1)
+        null
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (orderId == -1) finish()
+        if (order == null) finish()
         binding = DataBindingUtil.setContentView(this, R.layout.activity_order_detail)
 
+        initViewModel()
         initButton()
         initAdapter()
     }
 
+    private fun initViewModel() {
+        viewModel.getOrderDetail(order!!.id)
+        viewModel.orderItemUiState.flowWithLifecycle(this.lifecycle)
+            .onEach {
+                when (it) {
+                    is UiState.Success -> orderDetailRVAdapter.submitOrderItemList(it.data)
+                    is UiState.Error -> showToast(it.message)
+                    else -> {}
+                }
+            }
+    }
+
     private fun initAdapter() {
-        orderDetailRVAdapter = OrderDetailRVAdapter()
+        orderDetailRVAdapter = OrderDetailRVAdapter(order!!)
         binding.rvOrderDetail.adapter = orderDetailRVAdapter
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailActivity.kt
@@ -5,14 +5,34 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.ActivityOrderDetailBinding
+import com.woowa.banchan.ui.order.detail.adapter.OrderDetailRVAdapter
 
 class OrderDetailActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityOrderDetailBinding
+    private lateinit var orderDetailRVAdapter: OrderDetailRVAdapter
+
+    private val orderId: Int by lazy {
+        intent.getIntExtra("orderId", -1)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        if (orderId == -1) finish()
         binding = DataBindingUtil.setContentView(this, R.layout.activity_order_detail)
+
+        initButton()
+        initAdapter()
+    }
+
+    private fun initAdapter() {
+        orderDetailRVAdapter = OrderDetailRVAdapter()
+        binding.rvOrderDetail.adapter = orderDetailRVAdapter
+    }
+
+    private fun initButton() {
+        binding.ctbSubToolbar.setOnClickBackIcon { finish() }
+        binding.ctbSubToolbar.setOnClickRefreshIcon { }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailRVTag.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailRVTag.kt
@@ -1,0 +1,6 @@
+package com.woowa.banchan.ui.order.detail
+
+// Order Activity Adapter Tag
+const val ORDER_HEADER = 0
+const val ORDER_CONTENT = 1
+const val ORDER_TOTAL_PRICE = 2

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailViewModel.kt
@@ -1,0 +1,29 @@
+package com.woowa.banchan.ui.order.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woowa.banchan.domain.model.Order
+import com.woowa.banchan.domain.model.OrderItem
+import com.woowa.banchan.domain.usecase.order.inter.GetOrderDetailUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderDetailViewModel @Inject constructor(
+    private val getOrderDetailUseCase: GetOrderDetailUseCase,
+) : ViewModel() {
+
+    private val _orderItemUiState = MutableStateFlow<UiState<List<OrderItem>>>(UiState.Empty)
+    val orderItemUiState: StateFlow<UiState<List<OrderItem>>> get() = _orderItemUiState
+
+    private val _orderUiState = MutableStateFlow<UiState<Order>>(UiState.Empty)
+    val orderUiState: StateFlow<UiState<Order>> get() = _orderUiState
+
+    fun getOrderDetail(orderId: Long) = viewModelScope.launch {
+        getOrderDetailUseCase(orderId).collect { _orderItemUiState.emit(it) }
+    }
+}

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/OrderDetailRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/OrderDetailRVAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemOrderDetailBinding
 import com.woowa.banchan.databinding.ItemOrderDetailHeaderBinding
 import com.woowa.banchan.databinding.ItemTotalPriceBinding
+import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.domain.model.OrderItem
 import com.woowa.banchan.ui.cart.cart.adapter.viewholder.TotalPriceViewHolder
 import com.woowa.banchan.ui.order.detail.ORDER_CONTENT
@@ -16,7 +17,9 @@ import com.woowa.banchan.ui.order.detail.ORDER_TOTAL_PRICE
 import com.woowa.banchan.ui.order.detail.adapter.viewholder.OrderDetailHeaderViewHolder
 import com.woowa.banchan.ui.order.detail.adapter.viewholder.OrderDetailViewHolder
 
-class OrderDetailRVAdapter : ListAdapter<OrderItem, RecyclerView.ViewHolder>(diffUtil) {
+class OrderDetailRVAdapter(
+    private val orderData: Order
+) : ListAdapter<OrderItem, RecyclerView.ViewHolder>(diffUtil) {
 
     private var totalPrice = 0
 
@@ -48,8 +51,12 @@ class OrderDetailRVAdapter : ListAdapter<OrderItem, RecyclerView.ViewHolder>(dif
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
-            ORDER_HEADER -> (holder as OrderDetailHeaderViewHolder).bind()
-            ORDER_CONTENT -> (holder as OrderDetailViewHolder).bind()
+            ORDER_HEADER -> (holder as OrderDetailHeaderViewHolder).bind(
+                orderData.count,
+                orderData.deliveryState,
+                orderData.time
+            )
+            ORDER_CONTENT -> (holder as OrderDetailViewHolder).bind(getItem(position))
             else -> (holder as TotalPriceViewHolder).bind(totalPrice)
         }
     }
@@ -67,8 +74,13 @@ class OrderDetailRVAdapter : ListAdapter<OrderItem, RecyclerView.ViewHolder>(dif
     fun submitOrderItemList(list: List<OrderItem>) {
         val newList = mutableListOf<OrderItem?>()
 
+        totalPrice = 0
+
         newList.add(null)
-        list.forEach { newList.add(it) }
+        list.forEach {
+            totalPrice += (it.price * it.count)
+            newList.add(it)
+        }
         newList.add(null)
 
         submitList(newList)

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/OrderDetailRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/OrderDetailRVAdapter.kt
@@ -1,0 +1,86 @@
+package com.woowa.banchan.ui.order.detail.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemOrderDetailBinding
+import com.woowa.banchan.databinding.ItemOrderDetailHeaderBinding
+import com.woowa.banchan.databinding.ItemTotalPriceBinding
+import com.woowa.banchan.domain.model.OrderItem
+import com.woowa.banchan.ui.cart.cart.adapter.viewholder.TotalPriceViewHolder
+import com.woowa.banchan.ui.order.detail.ORDER_CONTENT
+import com.woowa.banchan.ui.order.detail.ORDER_HEADER
+import com.woowa.banchan.ui.order.detail.ORDER_TOTAL_PRICE
+import com.woowa.banchan.ui.order.detail.adapter.viewholder.OrderDetailHeaderViewHolder
+import com.woowa.banchan.ui.order.detail.adapter.viewholder.OrderDetailViewHolder
+
+class OrderDetailRVAdapter : ListAdapter<OrderItem, RecyclerView.ViewHolder>(diffUtil) {
+
+    private var totalPrice = 0
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            ORDER_HEADER -> OrderDetailHeaderViewHolder(
+                ItemOrderDetailHeaderBinding.inflate(
+                    LayoutInflater.from(
+                        parent.context
+                    ), parent, false
+                )
+            )
+            ORDER_CONTENT -> OrderDetailViewHolder(
+                ItemOrderDetailBinding.inflate(
+                    LayoutInflater.from(
+                        parent.context
+                    ), parent, false
+                )
+            )
+            else -> TotalPriceViewHolder(
+                ItemTotalPriceBinding.inflate(
+                    LayoutInflater.from(
+                        parent.context
+                    ), parent, false
+                )
+            )
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder.itemViewType) {
+            ORDER_HEADER -> (holder as OrderDetailHeaderViewHolder).bind()
+            ORDER_CONTENT -> (holder as OrderDetailViewHolder).bind()
+            else -> (holder as TotalPriceViewHolder).bind(totalPrice)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        val lastIdx = itemCount - 1
+
+        return when (position) {
+            0 -> ORDER_HEADER
+            lastIdx -> ORDER_CONTENT
+            else -> ORDER_TOTAL_PRICE
+        }
+    }
+
+    fun submitOrderItemList(list: List<OrderItem>) {
+        val newList = mutableListOf<OrderItem?>()
+
+        newList.add(null)
+        list.forEach { newList.add(it) }
+        newList.add(null)
+
+        submitList(newList)
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<OrderItem>() {
+            override fun areItemsTheSame(oldItem: OrderItem, newItem: OrderItem): Boolean =
+                oldItem == newItem
+
+            override fun areContentsTheSame(oldItem: OrderItem, newItem: OrderItem): Boolean =
+                oldItem.id == newItem.id
+        }
+    }
+}

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailHeaderViewHolder.kt
@@ -2,9 +2,15 @@ package com.woowa.banchan.ui.order.detail.adapter.viewholder
 
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemOrderDetailHeaderBinding
+import java.util.*
 
 class OrderDetailHeaderViewHolder(private val binding: ItemOrderDetailHeaderBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind() {}
+    fun bind(count: Int, state: Boolean, time: Date) {
+        binding.itemCount = count
+        binding.deliveryState = state
+        val leftTime = (System.currentTimeMillis() - time.time) / 60000
+        binding.leftTime = leftTime.toInt()
+    }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailHeaderViewHolder.kt
@@ -1,0 +1,10 @@
+package com.woowa.banchan.ui.order.detail.adapter.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemOrderDetailHeaderBinding
+
+class OrderDetailHeaderViewHolder(private val binding: ItemOrderDetailHeaderBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind() {}
+}

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailViewHolder.kt
@@ -1,0 +1,10 @@
+package com.woowa.banchan.ui.order.detail.adapter.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemOrderDetailBinding
+
+class OrderDetailViewHolder(private val binding: ItemOrderDetailBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind() {}
+}

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/viewholder/OrderDetailViewHolder.kt
@@ -2,9 +2,12 @@ package com.woowa.banchan.ui.order.detail.adapter.viewholder
 
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemOrderDetailBinding
+import com.woowa.banchan.domain.model.OrderItem
 
 class OrderDetailViewHolder(private val binding: ItemOrderDetailBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind() {}
+    fun bind(orderItem: OrderItem) {
+        binding.order = orderItem
+    }
 }

--- a/app/src/main/res/layout/activity_order_detail.xml
+++ b/app/src/main/res/layout/activity_order_detail.xml
@@ -1,21 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
     </data>
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.order.detail.OrderDetailActivity">
 
-        <!-- TODO: Update blank fragment layout -->
-        <TextView
+        <com.woowa.banchan.ui.common.custom.CustomToolbar
+            android:id="@+id/ctb_sub_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="@string/hello_blank_fragment" />
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:toolBarType="sub|sub_refresh"
+            app:toolbarTitle="" />
 
-    </FrameLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_order_detail"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/greyscale_background"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ctb_sub_toolbar" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_order_detail.xml
+++ b/app/src/main/res/layout/item_order_detail.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="order"
+            type="com.woowa.banchan.domain.model.OrderItem" />
+
+        <import type="android.view.View" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_order_root"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="8dp">
+
+        <ImageView
+            android:id="@+id/iv_thumbnail"
+            android:layout_width="80dp"
+            android:layout_height="0dp"
+            android:src="@drawable/ic_user"
+            app:image="@{order.imageUrl}"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/normal_14"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            app:layout_constraintBottom_toTopOf="@id/tv_count"
+            app:layout_constraintStart_toEndOf="@id/iv_thumbnail"
+            app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
+            tools:text="새콤달콤 오징어무침" />
+
+        <TextView
+            android:id="@+id/tv_count"
+            style="@style/normal_14"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{@string/order_item_count(0)}"
+            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
+            tools:text="1개" />
+
+        <TextView
+            android:id="@+id/tv_total_price"
+            style="@style/normal_14"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_count"
+            app:price="@{order.price}"
+            tools:text="12,640원" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_order_detail_header.xml
+++ b/app/src/main/res/layout/item_order_detail_header.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="leftTime"
+            type="Integer" />
+
+        <variable
+            name="itemCount"
+            type="Integer" />
+
+        <variable
+            name="deliveryState"
+            type="Boolean" />
+
+        <import type="android.view.View" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                style="@style/label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingVertical="8dp"
+                android:text="주문이 접수되었습니다."
+                android:visibility="@{deliveryState ? View.VISIBLE : View.GONE}" />
+
+            <TextView
+                style="@style/label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingVertical="8dp"
+                android:text="배송이 완료되었습니다."
+                android:visibility="@{deliveryState ? View.GONE : View.VISIBLE}" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="@{deliveryState ? View.VISIBLE : View.GONE}">
+
+                <TextView
+                    style="@style/normal_grey_14"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="배송까지 남은 시간 " />
+
+                <TextView
+                    android:id="@+id/tv_left_time"
+                    style="@style/normal_14"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@{@string/order_left_minute(leftTime)}"
+                    tools:text="20" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingVertical="8dp">
+
+                <TextView
+                    style="@style/normal_grey_14"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="주문한 상품 " />
+
+                <TextView
+                    android:id="@+id/tv_item_count"
+                    style="@style/normal_14"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@{@string/order_total_count(itemCount)}"
+                    tools:text="총 2개" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,8 @@
     <string name="empty_notice">상품이 비어있습니다!</string>
 
     <string name="total_count">총 %d개 상품</string>
+
+    <string name="order_total_count">총 %d개</string>
+    <string name="order_item_count">%d개</string>
+    <string name="order_left_minute">%d분</string>
 </resources>


### PR DESCRIPTION
### ❗️ 이슈
- close #50 

### 📝 구현한 내용
- Order Detail 화면 구현하기
  - Order Detail layout 구현
  - RecyclerView Adapter 구현 및 부착
  - ToolBar 기능 구현 및 타이틀 설정
  - 받아온 orderId가 없을 경우 해당 화면은 즉시 종료한다.
- Order Detail 화면 Data Load
  - Database에서 Order Detail Data Load
  - datasource 및 repository, usecase 의존성 주입