### PR TITLE
feat: insert Cart 기능 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 
     //Room
     implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 
     //Hilt

--- a/app/src/main/java/com/woowa/banchan/data/local/dao/CartDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/CartDao.kt
@@ -8,14 +8,14 @@ import com.woowa.banchan.data.local.entity.CartDto
 interface CartDao {
 
     @Insert
-    fun insert(cartDto: CartDto)
+    suspend fun insertCart(cartDto: CartDto)
 
     @Update
-    fun update(cartDto: CartDto)
+    suspend fun updateCart(cartDto: CartDto)
 
     @Delete
-    fun delete(cartDto: CartDto)
+    suspend fun deleteCart(cartDto: CartDto)
 
     @Query("SELECT * FROM $cartTable")
-    fun getCartList(): List<CartDto>
+    suspend fun getCartList(): List<CartDto>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
@@ -6,5 +6,5 @@ interface CartDataSource {
 
     suspend fun getCartList(): Result<List<CartDto>>
 
-    suspend fun insertCart(cartDto: CartDto)
+    suspend fun insertCart(cartDto: CartDto): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
@@ -5,4 +5,6 @@ import com.woowa.banchan.data.local.entity.CartDto
 interface CartDataSource {
 
     suspend fun getCartList(): Result<List<CartDto>>
+
+    suspend fun insertCart(cartDto: CartDto)
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
@@ -10,4 +10,8 @@ class CartDataSourceImpl @Inject constructor(
 
     override suspend fun getCartList(): Result<List<CartDto>> =
         runCatching { cartDao.getCartList() }
+
+    override suspend fun insertCart(cartDto: CartDto) {
+        cartDao.insertCart(cartDto)
+    }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
@@ -11,7 +11,7 @@ class CartDataSourceImpl @Inject constructor(
     override suspend fun getCartList(): Result<List<CartDto>> =
         runCatching { cartDao.getCartList() }
 
-    override suspend fun insertCart(cartDto: CartDto) {
-        cartDao.insertCart(cartDto)
-    }
+    override suspend fun insertCart(cartDto: CartDto): Result<Unit> =
+        runCatching { cartDao.insertCart(cartDto) }
+
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
@@ -24,3 +24,12 @@ fun CartDto.toCart(): Cart = Cart(
     title = title,
     imageUrl = imageUrl
 )
+
+fun Cart.toCartDto(): CartDto = CartDto(
+    hash = hash,
+    checkState = checkState,
+    price = price,
+    count = count,
+    title = title,
+    imageUrl = imageUrl
+)

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderDto.kt
@@ -5,7 +5,6 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.woowa.banchan.data.local.BanchanDataBase.Companion.orderTable
 import com.woowa.banchan.domain.model.Order
-import com.woowa.banchan.utils.DateUtil
 import java.util.*
 
 @Entity(tableName = orderTable)

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.cart.CartDataSource
 import com.woowa.banchan.data.local.entity.toCart
+import com.woowa.banchan.data.local.entity.toCartDto
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.repository.CartRepository
 import javax.inject.Inject
@@ -13,5 +14,9 @@ class CartRepositoryImpl @Inject constructor(
     override suspend fun getCartList(): Result<List<Cart>> {
         val list = cartDataSource.getCartList().getOrThrow()
         return runCatching { list.map { it.toCart() } }
+    }
+
+    override suspend fun insertCart(cart: Cart): Result<Unit> {
+        return kotlin.runCatching { cartDataSource.insertCart(cart.toCartDto()) }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -17,6 +17,6 @@ class CartRepositoryImpl @Inject constructor(
     }
 
     override suspend fun insertCart(cart: Cart): Result<Unit> {
-        return kotlin.runCatching { cartDataSource.insertCart(cart.toCartDto()) }
+        return runCatching { cartDataSource.insertCart(cart.toCartDto()) }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -16,7 +16,9 @@ class CartRepositoryImpl @Inject constructor(
         return runCatching { list.map { it.toCart() } }
     }
 
-    override suspend fun insertCart(cart: Cart): Result<Unit> {
-        return runCatching { cartDataSource.insertCart(cart.toCartDto()) }
-    }
+    override suspend fun insertCart(cart: Cart): Result<Unit> =
+        runCatching {
+            cartDataSource.insertCart(cart.toCartDto()).getOrThrow()
+        }
+
 }

--- a/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
+++ b/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
@@ -1,7 +1,9 @@
 package com.woowa.banchan.di
 
 import com.woowa.banchan.domain.usecase.cart.GetCartListUseCaseImpl
+import com.woowa.banchan.domain.usecase.cart.InsertCartUseCaseImpl
 import com.woowa.banchan.domain.usecase.cart.inter.GetCartListUseCase
+import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
 import com.woowa.banchan.domain.usecase.food.GetBestFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.GetDetailFoodUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.GetFoodsUseCaseImpl
@@ -41,6 +43,12 @@ abstract class UseCaseModule {
     abstract fun provideGetCartListUseCase(
         GetCartListUseCase: GetCartListUseCaseImpl
     ): GetCartListUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideInsertCartUseCase(
+        insertCartUseCase: InsertCartUseCaseImpl
+    ): InsertCartUseCase
 
     @Singleton
     @Binds

--- a/app/src/main/java/com/woowa/banchan/domain/model/FoodItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/FoodItem.kt
@@ -8,4 +8,14 @@ data class FoodItem(
     val sPrice: Int,
     val percent: Int?,
     val title: String
-)
+) {
+    fun toCart(totalCount: Int, checkState: Boolean) : Cart =
+        Cart(
+            hash = detailHash,
+            checkState = checkState,
+            price = sPrice,
+            count = totalCount,
+            title = title,
+            imageUrl = image
+        )
+}

--- a/app/src/main/java/com/woowa/banchan/domain/model/FoodItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/FoodItem.kt
@@ -9,7 +9,7 @@ data class FoodItem(
     val percent: Int?,
     val title: String
 ) {
-    fun toCart(totalCount: Int, checkState: Boolean) : Cart =
+    fun toCart(totalCount: Int, checkState: Boolean): Cart =
         Cart(
             hash = detailHash,
             checkState = checkState,

--- a/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
@@ -5,4 +5,6 @@ import com.woowa.banchan.domain.model.Cart
 interface CartRepository {
 
     suspend fun getCartList(): Result<List<Cart>>
+
+    suspend fun insertCart(cart: Cart): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/InsertCartUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/InsertCartUseCaseImpl.kt
@@ -1,0 +1,24 @@
+package com.woowa.banchan.domain.usecase.cart
+
+import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.domain.repository.CartRepository
+import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class InsertCartUseCaseImpl @Inject constructor(
+    private val cartRepository: CartRepository
+): InsertCartUseCase {
+    override suspend fun insertCart(foodItem: FoodItem, totalCount: Int): Flow<UiState<Unit>> =
+        flow {
+            emit(UiState.Loading)
+            cartRepository.insertCart(foodItem.toCart(totalCount,true))
+                .onSuccess { emit(UiState.Success(it)) }
+                .onFailure { emit(UiState.Error(it.message)) }
+        }.flowOn(Dispatchers.IO)
+
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/InsertCartUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/InsertCartUseCaseImpl.kt
@@ -12,11 +12,11 @@ import javax.inject.Inject
 
 class InsertCartUseCaseImpl @Inject constructor(
     private val cartRepository: CartRepository
-): InsertCartUseCase {
+) : InsertCartUseCase {
     override suspend fun insertCart(foodItem: FoodItem, totalCount: Int): Flow<UiState<Unit>> =
         flow {
             emit(UiState.Loading)
-            cartRepository.insertCart(foodItem.toCart(totalCount,true))
+            cartRepository.insertCart(foodItem.toCart(totalCount, true))
                 .onSuccess { emit(UiState.Success(it)) }
                 .onFailure { emit(UiState.Error(it.message)) }
         }.flowOn(Dispatchers.IO)

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/InsertCartUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/InsertCartUseCase.kt
@@ -1,3 +1,10 @@
 package com.woowa.banchan.domain.usecase.cart.inter
 
-interface InsertCartUseCase
+import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.flow.Flow
+
+interface InsertCartUseCase {
+    suspend fun insertCart(foodItem: FoodItem, totalCount: Int): Flow<UiState<Unit>>
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/InsertCartUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/InsertCartUseCase.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.domain.usecase.cart.inter
 
-import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -8,6 +8,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentCartBinding
 import com.woowa.banchan.domain.model.Cart
@@ -15,6 +16,7 @@ import com.woowa.banchan.ui.cart.CartViewModel
 import com.woowa.banchan.ui.cart.cart.adapter.CartRVAdapter
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.utils.showToast
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 class CartFragment : Fragment() {
@@ -71,7 +73,7 @@ class CartFragment : Fragment() {
                     is UiState.Error -> showToast(it.message)
                     else -> {}
                 }
-            }
+            }.launchIn(lifecycleScope)
         viewModel.recentUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
                 when (it) {

--- a/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
@@ -15,6 +15,9 @@ class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragmen
 
     private lateinit var binding: FragmentCartAddBinding
 
+    private var totalPrice = foodItem.sPrice
+    private var totalCount = 1
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -25,6 +28,37 @@ class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragmen
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.food = foodItem
+        initBinding()
+        initButtonSetting()
+    }
+
+    private fun initBinding() {
+        binding.apply {
+            food = foodItem
+            price = totalPrice
+            count = totalCount
+        }
+    }
+
+    private fun initButtonSetting() {
+        binding.tvCancel.setOnClickListener { dismiss() }
+        binding.ivPlus.setOnClickListener {
+            totalCount++
+            totalPrice = totalCount * foodItem.sPrice
+            setCountAndPrice()
+        }
+
+        binding.ivMinus.setOnClickListener {
+            if(totalCount > 1) {
+                totalCount--
+                totalPrice = totalCount * foodItem.sPrice
+                setCountAndPrice()
+            }
+        }
+    }
+
+    private fun setCountAndPrice() {
+        binding.count = totalCount
+        binding.price = totalPrice
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
@@ -4,15 +4,25 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woowa.banchan.R
+import com.woowa.banchan.databinding.FragmentCartAddBinding
 
-class CartAddFragment : Fragment() {
+class CartAddFragment : BottomSheetDialogFragment() {
+
+    private lateinit var binding: FragmentCartAddBinding
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_cart_add, container, false)
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_cart_add, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -14,8 +13,6 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentCartAddBinding
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.uistate.UiState
-import com.woowa.banchan.ui.detail.adapter.DetailRVAdapter
-import com.woowa.banchan.ui.detail.adapter.DetailVPAdapter
 import com.woowa.banchan.utils.showToast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -74,7 +71,7 @@ class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragmen
         }
 
         binding.ivMinus.setOnClickListener {
-            if(totalCount > 1) {
+            if (totalCount > 1) {
                 totalCount--
                 totalPrice = totalCount * foodItem.sPrice
                 setCountAndPrice()

--- a/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
@@ -9,8 +9,9 @@ import androidx.fragment.app.Fragment
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentCartAddBinding
+import com.woowa.banchan.domain.model.FoodItem
 
-class CartAddFragment : BottomSheetDialogFragment() {
+class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragment() {
 
     private lateinit var binding: FragmentCartAddBinding
 
@@ -24,5 +25,6 @@ class CartAddFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.food = foodItem
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddFragment.kt
@@ -6,17 +6,30 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentCartAddBinding
 import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.ui.detail.adapter.DetailRVAdapter
+import com.woowa.banchan.ui.detail.adapter.DetailVPAdapter
+import com.woowa.banchan.utils.showToast
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
+@AndroidEntryPoint
 class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragment() {
 
     private lateinit var binding: FragmentCartAddBinding
 
     private var totalPrice = foodItem.sPrice
     private var totalCount = 1
+
+    private val viewModel: CartAddViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -29,6 +42,7 @@ class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragmen
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initBinding()
+        initObserve()
         initButtonSetting()
     }
 
@@ -38,6 +52,17 @@ class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragmen
             price = totalPrice
             count = totalCount
         }
+    }
+
+    private fun initObserve() {
+        viewModel.insertionUiState.flowWithLifecycle(lifecycle)
+            .onEach { state ->
+                if (state is UiState.Success) {
+                    dismiss()
+                } else if (state is UiState.Error) {
+                    showToast(state.message)
+                }
+            }.launchIn(lifecycleScope)
     }
 
     private fun initButtonSetting() {
@@ -55,6 +80,8 @@ class CartAddFragment(private val foodItem: FoodItem) : BottomSheetDialogFragmen
                 setCountAndPrice()
             }
         }
+
+        binding.btnAdd.setOnClickListener { viewModel.insertCart(foodItem, totalCount) }
     }
 
     private fun setCountAndPrice() {

--- a/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddViewModel.kt
@@ -2,7 +2,6 @@ package com.woowa.banchan.ui.common.bottomsheet
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
 import com.woowa.banchan.ui.common.uistate.UiState
@@ -10,7 +9,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 

--- a/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/bottomsheet/CartAddViewModel.kt
@@ -1,0 +1,32 @@
+package com.woowa.banchan.ui.common.bottomsheet
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CartAddViewModel @Inject constructor(
+    private val insertCartUseCase: InsertCartUseCase
+) : ViewModel() {
+    private val _insertionUiState = MutableStateFlow<UiState<Unit>>(UiState.Empty)
+    val insertionUiState: StateFlow<UiState<Unit>> get() = _insertionUiState.asStateFlow()
+
+    fun insertCart(foodItem: FoodItem, totalCount: Int) {
+        viewModelScope.launch {
+            insertCartUseCase.insertCart(foodItem, totalCount).collect { uiState ->
+                _insertionUiState.emit(uiState)
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/woowa/banchan/ui/detail/viewholder/DetailVPViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/viewholder/DetailVPViewHolder.kt
@@ -1,7 +1,6 @@
 package com.woowa.banchan.ui.detail.viewholder
 
 import androidx.recyclerview.widget.RecyclerView
-import com.woowa.banchan.databinding.ItemRvDetailBinding
 import com.woowa.banchan.databinding.ItemVpDetailBinding
 
 class DetailVPViewHolder(private val binding: ItemVpDetailBinding) : RecyclerView.ViewHolder(binding.root) {

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
@@ -12,7 +12,7 @@ import com.woowa.banchan.ui.home.adapter.viewholder.HomeItemViewHolder
 
 class HomeRVAdapter(
     private val itemClickListener: (String, String) -> Unit,
-    private val cartClickListener: () -> Unit
+    private val cartClickListener: (FoodItem) -> Unit
 ) :
     ListAdapter<FoodItem, HomeItemViewHolder>(diffUtil) {
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
@@ -10,7 +10,10 @@ import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.home.LINEAR_VERTICAL
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeItemViewHolder
 
-class HomeRVAdapter(private val itemClickListener: (String, String) -> Unit) :
+class HomeRVAdapter(
+    private val itemClickListener: (String, String) -> Unit,
+    private val cartClickListener: () -> Unit
+) :
     ListAdapter<FoodItem, HomeItemViewHolder>(diffUtil) {
 
     var managerType: Int = LINEAR_VERTICAL
@@ -36,7 +39,7 @@ class HomeRVAdapter(private val itemClickListener: (String, String) -> Unit) :
     }
 
     override fun onBindViewHolder(holder: HomeItemViewHolder, position: Int) {
-        holder.bind(getItem(position), itemClickListener)
+        holder.bind(getItem(position), itemClickListener, cartClickListener)
     }
 
     companion object {

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
@@ -9,16 +9,22 @@ import com.woowa.banchan.domain.model.FoodItem
 class HomeItemViewHolder(private val binding: ViewDataBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(food: FoodItem, itemClickListener: (String, String) -> Unit) {
+    fun bind(food: FoodItem, itemClickListener: (String, String) -> Unit, cartClickListener: () -> Unit) {
         if (binding is ItemHomeBinding) {
             binding.food = food
             binding.layoutHome.setOnClickListener {
                 itemClickListener(food.title, food.detailHash)
             }
+            binding.ivCart.setOnClickListener {
+                cartClickListener()
+            }
         } else if (binding is ItemMainLinearBinding) {
             binding.food = food
             binding.layoutMain.setOnClickListener {
                 itemClickListener(food.title, food.detailHash)
+            }
+            binding.ivCart.setOnClickListener {
+                cartClickListener()
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
@@ -9,14 +9,14 @@ import com.woowa.banchan.domain.model.FoodItem
 class HomeItemViewHolder(private val binding: ViewDataBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(food: FoodItem, itemClickListener: (String, String) -> Unit, cartClickListener: () -> Unit) {
+    fun bind(food: FoodItem, itemClickListener: (String, String) -> Unit, cartClickListener: (FoodItem) -> Unit) {
         if (binding is ItemHomeBinding) {
             binding.food = food
             binding.layoutHome.setOnClickListener {
                 itemClickListener(food.title, food.detailHash)
             }
             binding.ivCart.setOnClickListener {
-                cartClickListener()
+                cartClickListener(food)
             }
         } else if (binding is ItemMainLinearBinding) {
             binding.food = food
@@ -24,7 +24,7 @@ class HomeItemViewHolder(private val binding: ViewDataBinding) :
                 itemClickListener(food.title, food.detailHash)
             }
             binding.ivCart.setOnClickListener {
-                cartClickListener()
+                cartClickListener(food)
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentBestBinding
+import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.detail.DetailActivity
 import com.woowa.banchan.ui.home.best.adapter.BestRVAdapter
@@ -28,7 +29,7 @@ class BestFragment : Fragment() {
     private val viewModel: BestViewModel by viewModels()
 
     private val bestAdapter: BestRVAdapter by lazy {
-        BestRVAdapter(itemClickListener)
+        BestRVAdapter(itemClickListener, cartClickListener)
     }
 
     private val itemClickListener: (String, String) -> Unit = { title, hash ->
@@ -36,6 +37,10 @@ class BestFragment : Fragment() {
         intent.putExtra("title", title)
         intent.putExtra("hash", hash)
         startActivity(intent)
+    }
+
+    private val cartClickListener: () -> Unit = {
+        CartAddFragment().show(childFragmentManager, "")
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/BestFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentBestBinding
+import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.detail.DetailActivity
@@ -39,8 +40,8 @@ class BestFragment : Fragment() {
         startActivity(intent)
     }
 
-    private val cartClickListener: () -> Unit = {
-        CartAddFragment().show(childFragmentManager, "")
+    private val cartClickListener: (FoodItem) -> Unit = { food ->
+        CartAddFragment(food).show(childFragmentManager, "")
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -55,7 +55,7 @@ class BestRVAdapter(
             HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("한 번 주문하면\n두 번 반하는 반찬들", true)
             SUB_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position))
             else -> (holder as HomeRecyclerViewViewHolder).bind(
-                HomeRVAdapter(itemClickListener,cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
+                HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
                 getItem(position).items,
                 LINEAR_HORIZONTAL,
             )

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -9,6 +9,7 @@ import com.woowa.banchan.databinding.ItemBestHeaderBinding
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.domain.model.BestFoodCategory
+import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.home.HOME_HEADER
 import com.woowa.banchan.ui.home.HOME_ITEM
 import com.woowa.banchan.ui.home.LINEAR_HORIZONTAL
@@ -20,7 +21,7 @@ import com.woowa.banchan.ui.home.best.adapter.viewholder.BestHeaderViewHolder
 
 class BestRVAdapter(
     private val itemClickListener: (String, String) -> Unit,
-    private val cartClickListener: () -> Unit
+    private val cartClickListener: (FoodItem) -> Unit
 ) : ListAdapter<BestFoodCategory, RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -18,7 +18,10 @@ import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestHeaderViewHolder
 
-class BestRVAdapter(private val itemClickListener: (String, String) -> Unit) : ListAdapter<BestFoodCategory, RecyclerView.ViewHolder>(diffUtil) {
+class BestRVAdapter(
+    private val itemClickListener: (String, String) -> Unit,
+    private val cartClickListener: () -> Unit
+) : ListAdapter<BestFoodCategory, RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
@@ -51,7 +54,7 @@ class BestRVAdapter(private val itemClickListener: (String, String) -> Unit) : L
             HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("한 번 주문하면\n두 번 반하는 반찬들", true)
             SUB_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position))
             else -> (holder as HomeRecyclerViewViewHolder).bind(
-                HomeRVAdapter(itemClickListener).apply { managerType = LINEAR_HORIZONTAL },
+                HomeRVAdapter(itemClickListener,cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
                 getItem(position).items,
                 LINEAR_HORIZONTAL,
             )

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMainBinding
+import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.detail.DetailActivity
@@ -39,8 +40,8 @@ class MainFragment : Fragment() {
         viewModel.sortList(position)
     }
 
-    private val cartClickListener: () -> Unit = {
-        CartAddFragment().show(childFragmentManager, "")
+    private val cartClickListener: (FoodItem) -> Unit = { food ->
+        CartAddFragment(food).show(childFragmentManager, "")
     }
 
     private val checkedChangeListener: (RadioGroup, Int) -> Unit = { group, checkedId ->

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMainBinding
+import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.detail.DetailActivity
 import com.woowa.banchan.ui.home.GRID
@@ -31,11 +32,15 @@ class MainFragment : Fragment() {
     private val viewModel: MainViewModel by viewModels()
 
     private val mainAdapter: MainRVAdapter by lazy {
-        MainRVAdapter(checkedChangeListener, spinnerCallback, itemClickListener)
+        MainRVAdapter(checkedChangeListener, spinnerCallback, itemClickListener, cartClickListener)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
         viewModel.sortList(position)
+    }
+
+    private val cartClickListener: () -> Unit = {
+        CartAddFragment().show(childFragmentManager, "")
     }
 
     private val checkedChangeListener: (RadioGroup, Int) -> Unit = { group, checkedId ->

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -23,7 +23,7 @@ class MainRVAdapter(
     private val checkedChangeListener: (RadioGroup, Int) -> Unit,
     private val spinnerCallback: (Int) -> Unit,
     itemClickListener: (String, String) -> Unit,
-    cartClickListener: () -> Unit
+    cartClickListener: (FoodItem) -> Unit
 ) :
     ListAdapter<List<FoodItem>, RecyclerView.ViewHolder>(diffUtil) {
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -22,12 +22,13 @@ import com.woowa.banchan.ui.home.main.adapter.viewholder.MainHeaderViewHolder
 class MainRVAdapter(
     private val checkedChangeListener: (RadioGroup, Int) -> Unit,
     private val spinnerCallback: (Int) -> Unit,
-    private val itemClickListener: (String, String) -> Unit
+    itemClickListener: (String, String) -> Unit,
+    cartClickListener: () -> Unit
 ) :
     ListAdapter<List<FoodItem>, RecyclerView.ViewHolder>(diffUtil) {
 
     var managerType = GRID
-    val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener).apply { managerType = GRID }
+    val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {

--- a/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSoupBinding
+import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.detail.DetailActivity
 import com.woowa.banchan.ui.home.soup.adapter.SoupRVAdapter
@@ -28,7 +29,7 @@ class SoupFragment : Fragment() {
     private val viewModel: SoupViewModel by viewModels()
 
     private val soupAdapter: SoupRVAdapter by lazy {
-        SoupRVAdapter(spinnerCallback, itemClickListener)
+        SoupRVAdapter(spinnerCallback, itemClickListener, cartClickListener)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
@@ -40,6 +41,10 @@ class SoupFragment : Fragment() {
         intent.putExtra("title", title)
         intent.putExtra("hash", hash)
         startActivity(intent)
+    }
+
+    private val cartClickListener: () -> Unit = {
+        CartAddFragment().show(childFragmentManager, "")
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSoupBinding
+import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.detail.DetailActivity
@@ -43,8 +44,8 @@ class SoupFragment : Fragment() {
         startActivity(intent)
     }
 
-    private val cartClickListener: () -> Unit = {
-        CartAddFragment().show(childFragmentManager, "")
+    private val cartClickListener: (FoodItem) -> Unit = { food ->
+        CartAddFragment(food).show(childFragmentManager, "")
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/woowa/banchan/ui/home/soup/adapter/SoupRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/soup/adapter/SoupRVAdapter.kt
@@ -21,7 +21,7 @@ import com.woowa.banchan.ui.home.soup.adapter.viewholder.SoupSideHeaderViewHolde
 class SoupRVAdapter(
     private val spinnerCallback: (Int) -> Unit,
     itemClickListener: (String, String) -> Unit,
-    cartClickListener: () -> Unit
+    cartClickListener: (FoodItem) -> Unit
 ) :
     ListAdapter<List<FoodItem>, RecyclerView.ViewHolder>(diffUtil) {
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/soup/adapter/SoupRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/soup/adapter/SoupRVAdapter.kt
@@ -18,11 +18,15 @@ import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
 import com.woowa.banchan.ui.home.soup.adapter.viewholder.SoupSideHeaderViewHolder
 
-class SoupRVAdapter(private val spinnerCallback: (Int) -> Unit, private val itemClickListener: (String, String) -> Unit) :
+class SoupRVAdapter(
+    private val spinnerCallback: (Int) -> Unit,
+    itemClickListener: (String, String) -> Unit,
+    cartClickListener: () -> Unit
+) :
     ListAdapter<List<FoodItem>, RecyclerView.ViewHolder>(diffUtil) {
 
     var managerType = GRID
-    private val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener).apply { managerType = GRID }
+    private val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {

--- a/app/src/main/res/drawable/background_bottomsheet.xml
+++ b/app/src/main/res/drawable/background_bottomsheet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <corners
-        android:topLeftRadius="24dp"
-        android:topRightRadius="24dp" />
+        android:topLeftRadius="@dimen/bottomsheet_radius"
+        android:topRightRadius="@dimen/bottomsheet_radius" />
     <solid android:color="@color/white" />
 </shape>

--- a/app/src/main/res/drawable/background_bottomsheet.xml
+++ b/app/src/main/res/drawable/background_bottomsheet.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:topLeftRadius="24dp"
+        android:topRightRadius="24dp" />
+    <solid android:color="@color/white" />
+</shape>

--- a/app/src/main/res/layout/fragment_cart_add.xml
+++ b/app/src/main/res/layout/fragment_cart_add.xml
@@ -138,21 +138,23 @@
             style="@style/normal_14"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="@id/iv_minus"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/iv_minus"
-            app:layout_constraintBottom_toBottomOf="@id/iv_minus"
-            tools:text="12,640원"/>
+            tools:text="12,640원" />
 
         <Button
             android:id="@+id/btn_add"
-            style="@style/button"
+            style="@style/normal_white_18"
             android:layout_width="0dp"
             android:layout_height="64dp"
             android:layout_marginTop="24dp"
-            app:layout_constraintStart_toStartOf="parent"
+            android:text="1개 담기"
+            android:layout_marginBottom="8dp"
+            app:backgroundTint="@color/main"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/iv_minus"
-            tools:text="1개 담기"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_minus" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_cart_add.xml
+++ b/app/src/main/res/layout/fragment_cart_add.xml
@@ -9,6 +9,14 @@
             name="food"
             type="com.woowa.banchan.domain.model.FoodItem" />
 
+        <variable
+            name="count"
+            type="Integer" />
+
+        <variable
+            name="price"
+            type="Integer" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -42,9 +50,9 @@
             android:layout_width="64dp"
             android:layout_height="64dp"
             android:layout_marginTop="24dp"
+            app:image="@{food.image}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_bottomsheet_title"
-            app:image="@{food.image}"
             tools:src="@color/main" />
 
         <TextView
@@ -118,10 +126,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingHorizontal="24dp"
-            android:text="1"
+            android:text="@{Integer.toString(count)}"
             app:layout_constraintBottom_toBottomOf="@id/iv_plus"
             app:layout_constraintEnd_toStartOf="@id/iv_plus"
-            app:layout_constraintTop_toTopOf="@id/iv_plus" />
+            app:layout_constraintTop_toTopOf="@id/iv_plus"
+            tools:text="1"/>
 
         <ImageView
             android:id="@+id/iv_minus"
@@ -143,6 +152,7 @@
             app:layout_constraintBottom_toBottomOf="@id/iv_minus"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/iv_minus"
+            app:price="@{price}"
             tools:text="12,640원" />
 
         <Button
@@ -151,8 +161,8 @@
             android:layout_width="0dp"
             android:layout_height="64dp"
             android:layout_marginTop="24dp"
-            android:text="1개 담기"
             android:layout_marginBottom="8dp"
+            android:text="1개 담기"
             app:backgroundTint="@color/main"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_cart_add.xml
+++ b/app/src/main/res/layout/fragment_cart_add.xml
@@ -1,16 +1,158 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/bottom_sheet_behavior"
-    tools:context=".ui.common.bottomsheet.CartAddFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <data>
+
+        <variable
+            name="food"
+            type="com.woowa.banchan.domain.model.FoodItem" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:layout_height="wrap_content"
+        android:background="@drawable/background_bottomsheet"
+        android:padding="16dp">
 
-</FrameLayout>
+        <TextView
+            android:id="@+id/tv_bottomsheet_title"
+            style="@style/normal_14"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/bottomsheet_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_cancel"
+            style="@style/normal_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/bottomsheet_cancel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_thumbnail"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_bottomsheet_title"
+            tools:src="@color/main" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/normal_14"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{food.title}"
+            app:layout_constraintBottom_toTopOf="@id/tv_s_price"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/iv_thumbnail"
+            app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
+            tools:text="오리 주물럭_반조리" />
+
+        <TextView
+            android:id="@+id/tv_percent"
+            style="@style/percent_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingEnd="4dp"
+            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            app:percent="@{food.percent}"
+            tools:text="20%" />
+
+        <TextView
+            android:id="@+id/tv_s_price"
+            style="@style/normal_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
+            app:layout_constraintStart_toEndOf="@id/tv_percent"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            app:nPrice="@{null}"
+            app:sPrice="@{food.sPrice}"
+            tools:text="12,640원" />
+
+        <TextView
+            android:id="@+id/tv_n_price"
+            style="@style/caption_grey"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:paddingStart="4dp"
+            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_s_price"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            app:nPrice="@{food.nPrice}"
+            app:sPrice="@{null}"
+            tools:text="15,800원" />
+
+        <ImageView
+            android:id="@+id/iv_plus"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginTop="24dp"
+            android:background="@drawable/circle_btn_background"
+            android:elevation="4dp"
+            android:padding="12dp"
+            android:src="@drawable/ic_plus"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_s_price" />
+
+        <TextView
+            android:id="@+id/tv_count"
+            style="@style/normal_18"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="24dp"
+            android:text="1"
+            app:layout_constraintBottom_toBottomOf="@id/iv_plus"
+            app:layout_constraintEnd_toStartOf="@id/iv_plus"
+            app:layout_constraintTop_toTopOf="@id/iv_plus" />
+
+        <ImageView
+            android:id="@+id/iv_minus"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginTop="24dp"
+            android:background="@drawable/circle_btn_background"
+            android:elevation="4dp"
+            android:padding="12dp"
+            android:src="@drawable/ic_minus"
+            app:layout_constraintEnd_toStartOf="@id/tv_count"
+            app:layout_constraintTop_toBottomOf="@id/tv_s_price" />
+
+        <TextView
+            android:id="@+id/tv_total_price"
+            style="@style/normal_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/iv_minus"
+            app:layout_constraintBottom_toBottomOf="@id/iv_minus"
+            tools:text="12,640원"/>
+
+        <Button
+            android:id="@+id/btn_add"
+            style="@style/button"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_marginTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_minus"
+            tools:text="1개 담기"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_cart_add.xml
+++ b/app/src/main/res/layout/fragment_cart_add.xml
@@ -8,6 +8,7 @@
         <variable
             name="food"
             type="com.woowa.banchan.domain.model.FoodItem" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -43,6 +44,7 @@
             android:layout_marginTop="24dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_bottomsheet_title"
+            app:image="@{food.image}"
             tools:src="@color/main" />
 
         <TextView
@@ -86,7 +88,7 @@
 
         <TextView
             android:id="@+id/tv_n_price"
-            style="@style/caption_grey"
+            style="@style/normal_grey_14"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingStart="4dp"

--- a/app/src/main/res/layout/fragment_cart_add.xml
+++ b/app/src/main/res/layout/fragment_cart_add.xml
@@ -162,7 +162,7 @@
             android:layout_height="64dp"
             android:layout_marginTop="24dp"
             android:layout_marginBottom="8dp"
-            android:text="1개 담기"
+            android:text="@{@string/add_cart(count)}"
             app:backgroundTint="@color/main"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -13,6 +13,7 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="bottomSheetDialogTheme">@style/BottomSheetDialog</item>
     </style>
 
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -12,6 +12,7 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="bottomSheetDialogTheme">@style/BottomSheetDialog</item>
     </style>
 
     <!--Splash Screen-->

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -13,6 +13,7 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="bottomSheetDialogTheme">@style/BottomSheetDialog</item>
     </style>
 
     <!--Splash Screen-->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="badge_radius">64dp</dimen>
     <dimen name="spinner_radius">16dp</dimen>
+    <dimen name="bottomsheet_radius">16dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,10 +24,12 @@
     <string name="order">주문하기</string>
 
     <string name="total_count">총 %d개 상품</string>
+    <string name="add_cart">%d개 담기</string>
 
     <string name="order_total_count">총 %d개</string>
     <string name="order_item_count">%d개</string>
     <string name="order_left_minute">%d분</string>
+
     <string name="bottomsheet_title">장바구니 담기</string>
     <string name="bottomsheet_cancel">취소</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="order_total_count">총 %d개</string>
     <string name="order_item_count">%d개</string>
     <string name="order_left_minute">%d분</string>
+    <string name="bottomsheet_title">장바구니 담기</string>
+    <string name="bottomsheet_cancel">취소</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -96,4 +96,15 @@
         <item name="android:textColor">@color/white</item>
     </style>
 
+    <style name="BottomSheetDialog" parent="@style/ThemeOverlay.MaterialComponents.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/BottomSheet</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+    </style>
+
+    <style name="BottomSheet" parent="Widget.MaterialComponents.BottomSheet.Modal">
+        <item name="backgroundTint">@android:color/transparent</item>
+    </style>
+
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,7 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="bottomSheetDialogTheme">@style/BottomSheetDialog</item>
     </style>
 
     <!--Splash Screen-->


### PR DESCRIPTION
### ❗️ 이슈
- close #41 

### 📝 구현한 내용
- BottomSheet 디자인
- 아이템 개수 조작 구현
- 카트 버튼 클릭시 BottomSheet 오픈
- Cart에 담기 db 로직 작성
- 확인 누를시 cart db에 insert

### 구현하지 못 한 내용
- Cart에 있는 item일시 아이콘 전환
  - 위 작업은 고민을 많이 해봐야 할 거 같아서 일단 미뤄두었습니다.

### ❓ 고민한 내용

- Cart에 담기 위해 FoodItem의 정보를 기반으로 BottomSheet를 오픈함
- FoodItem의 정보와 아이템의 개수를 조합하여 Cart로 변환해야 됨
- 위 작업은 어디에서?

UI 단에서 변환하여 UseCase에 넘겨주면 편하기도 하고 직관적일 수도 있지만,
위와 같이 객체를 변환하는 과정은 비즈니스 로직이라 생각하였고,
UseCase에서 변환 처리를 하였습니다.

insert된 Cart Item들이 리스트에 잘 보이나 CartActivity로 들어갔지만 아이템이 보이지 않아서
launchIn(lifeCycleScope)를 넣어서 해결하였습니다!
