### PR TITLE
feat: 장바구니 화면 데이터 기능 구현

### DIFF
--- a/app/src/main/java/com/woowa/banchan/data/local/dao/OrderDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/OrderDao.kt
@@ -8,7 +8,7 @@ import com.woowa.banchan.data.local.entity.OrderDto
 interface OrderDao {
 
     @Insert
-    fun insert(orderDto: OrderDto)
+    fun insert(orderDto: OrderDto): Long
 
     @Update
     fun update(orderDto: OrderDto)
@@ -18,4 +18,7 @@ interface OrderDao {
 
     @Query("SELECT * FROM $orderTable")
     fun getTotalOrderList(): List<OrderDto>
+
+    @Query("SELECT * FROM $orderTable WHERE id = :orderId")
+    fun getOrder(orderId: Long): OrderDto
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/dao/OrderItemDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/OrderItemDao.kt
@@ -8,7 +8,7 @@ import com.woowa.banchan.data.local.entity.OrderItemDto
 interface OrderItemDao {
 
     @Insert
-    fun insert(orderItemDto: OrderItemDto)
+    fun insert(vararg orderItemDto: OrderItemDto)
 
     @Update
     fun update(orderItemDto: OrderItemDto)

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
@@ -5,4 +5,8 @@ import com.woowa.banchan.data.local.entity.CartDto
 interface CartDataSource {
 
     suspend fun getCartList(): Result<List<CartDto>>
+
+    suspend fun updateCart(cartDto: CartDto): Result<Unit>
+
+    suspend fun deleteCart(cartDto: CartDto): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
@@ -12,10 +12,10 @@ class CartDataSourceImpl @Inject constructor(
         runCatching { cartDao.getCartList() }
 
     override suspend fun updateCart(cartDto: CartDto): Result<Unit> =
-        runCatching { cartDao.update(cartDto) }
+        runCatching { cartDao.updateCart(cartDto) }
 
     override suspend fun deleteCart(cartDto: CartDto): Result<Unit> =
-        runCatching { cartDao.delete(cartDto) }
+        runCatching { cartDao.deleteCart(cartDto) }
 
     override suspend fun insertCart(cartDto: CartDto): Result<Unit> =
         runCatching { cartDao.insertCart(cartDto) }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
@@ -10,4 +10,10 @@ class CartDataSourceImpl @Inject constructor(
 
     override suspend fun getCartList(): Result<List<CartDto>> =
         runCatching { cartDao.getCartList() }
+
+    override suspend fun updateCart(cartDto: CartDto): Result<Unit> =
+        runCatching { cartDao.update(cartDto) }
+
+    override suspend fun deleteCart(cartDto: CartDto): Result<Unit> =
+        runCatching { cartDao.delete(cartDto) }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSource.kt
@@ -7,4 +7,9 @@ interface OrderDataSource {
 
     suspend fun getTotalOrderList(): Result<List<OrderDto>>
     suspend fun getOrderDetail(orderId: Long): Result<List<OrderItemDto>>
+
+    suspend fun getOrder(orderId: Long): Result<OrderDto>
+
+    suspend fun insertNewOrder(orderDto: OrderDto): Result<Long>
+    suspend fun insertNewOrderItem(orderItemDto: List<OrderItemDto>): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSource.kt
@@ -12,4 +12,9 @@ interface OrderDataSource {
 
     suspend fun insertNewOrder(orderDto: OrderDto): Result<Long>
     suspend fun insertNewOrderItem(orderItemDto: List<OrderItemDto>): Result<Unit>
+
+    suspend fun insertNewOrderAndItem(
+        newOrder: OrderDto,
+        orderItemList: List<OrderItemDto>
+    ): Result<OrderDto>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSourceImpl.kt
@@ -17,4 +17,12 @@ class OrderDataSourceImpl @Inject constructor(
     override suspend fun getOrderDetail(orderId: Long): Result<List<OrderItemDto>> =
         runCatching { orderItemDao.getOrderDetail(orderId) }
 
+    override suspend fun getOrder(orderId: Long): Result<OrderDto> =
+        runCatching { orderDao.getOrder(orderId) }
+
+    override suspend fun insertNewOrder(orderDto: OrderDto): Result<Long> =
+        runCatching { orderDao.insert(orderDto) }
+
+    override suspend fun insertNewOrderItem(orderItemDto: List<OrderItemDto>): Result<Unit> =
+        runCatching { orderItemDto.forEach { orderItemDao.insert(it) } }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/order/OrderDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.data.local.datasource.order
 
+import com.woowa.banchan.data.local.BanchanDataBase
 import com.woowa.banchan.data.local.dao.OrderDao
 import com.woowa.banchan.data.local.dao.OrderItemDao
 import com.woowa.banchan.data.local.entity.OrderDto
@@ -8,7 +9,8 @@ import javax.inject.Inject
 
 class OrderDataSourceImpl @Inject constructor(
     private val orderDao: OrderDao,
-    private val orderItemDao: OrderItemDao
+    private val orderItemDao: OrderItemDao,
+    private val database: BanchanDataBase
 ) : OrderDataSource {
 
     override suspend fun getTotalOrderList(): Result<List<OrderDto>> =
@@ -24,5 +26,19 @@ class OrderDataSourceImpl @Inject constructor(
         runCatching { orderDao.insert(orderDto) }
 
     override suspend fun insertNewOrderItem(orderItemDto: List<OrderItemDto>): Result<Unit> =
-        runCatching { orderItemDto.forEach { orderItemDao.insert(it) } }
+        runCatching { orderItemDao.insert(*orderItemDto.toTypedArray()) }
+
+    override suspend fun insertNewOrderAndItem(
+        newOrder: OrderDto,
+        orderItemList: List<OrderItemDto>
+    ): Result<OrderDto> =
+        runCatching {
+            var orderId = 0L
+            database.runInTransaction {
+                orderId = orderDao.insert(newOrder)
+                orderItemList.forEach { it.orderId = orderId }
+                orderItemDao.insert(*orderItemList.toTypedArray())
+            }
+            orderDao.getOrder(orderId)
+        }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
@@ -33,3 +33,12 @@ fun CartDto.toOrderItemDto(orderId: Long): OrderItemDto = OrderItemDto(
     title = title,
     imageUrl = imageUrl
 )
+
+fun Cart.toCartDto() = CartDto(
+    hash = hash,
+    checkState = checkState,
+    price = price,
+    count = count,
+    title = title,
+    imageUrl = imageUrl
+)

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
@@ -24,3 +24,12 @@ fun CartDto.toCart(): Cart = Cart(
     title = title,
     imageUrl = imageUrl
 )
+
+fun CartDto.toOrderItemDto(orderId: Long): OrderItemDto = OrderItemDto(
+    id = -1,
+    orderId = orderId,
+    price = price,
+    count = count,
+    title = title,
+    imageUrl = imageUrl
+)

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderDto.kt
@@ -4,13 +4,13 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.woowa.banchan.data.local.BanchanDataBase.Companion.orderTable
+import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Order
-import com.woowa.banchan.utils.DateUtil
 import java.util.*
 
 @Entity(tableName = orderTable)
 data class OrderDto(
-    @PrimaryKey(autoGenerate = true) val id: Long,
+    @PrimaryKey(autoGenerate = true) val id: Long?,
     @ColumnInfo(name = "time") val time: Date,
     @ColumnInfo(name = "count") val count: Int,
     @ColumnInfo(name = "price") val price: Int,
@@ -20,7 +20,7 @@ data class OrderDto(
 
 fun OrderDto.toOrder(): Order {
     return Order(
-        id = id,
+        id = id!!,
         deliveryState = (System.currentTimeMillis() - time.time < (60000 * 20)),
         time = time,
         count = count,
@@ -29,3 +29,12 @@ fun OrderDto.toOrder(): Order {
         imageUrl = imageUrl
     )
 }
+
+fun newOrderDto(count: Int, price: Int, thumbnailItem: Cart): OrderDto = OrderDto(
+    id = null,
+    time = Date(System.currentTimeMillis()),
+    count = count,
+    price = price,
+    title = thumbnailItem.title,
+    imageUrl = thumbnailItem.imageUrl,
+)

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderItemDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderItemDto.kt
@@ -9,7 +9,7 @@ import com.woowa.banchan.domain.model.OrderItem
 @Entity(tableName = orderItemTable)
 data class OrderItemDto(
     @PrimaryKey(autoGenerate = true) val id: Long,
-    @ColumnInfo(name = "order_id") val orderId: Long,
+    @ColumnInfo(name = "order_id") var orderId: Long,
     @ColumnInfo(name = "count") val count: Int,
     @ColumnInfo(name = "price") val price: Int,
     @ColumnInfo(name = "title") val title: String,

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.cart.CartDataSource
 import com.woowa.banchan.data.local.entity.toCart
+import com.woowa.banchan.data.local.entity.toCartDto
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.repository.CartRepository
 import javax.inject.Inject

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -2,8 +2,8 @@ package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.cart.CartDataSource
 import com.woowa.banchan.data.local.entity.toCart
+import com.woowa.banchan.data.local.entity.toCartDto
 import com.woowa.banchan.domain.model.Cart
-import com.woowa.banchan.domain.model.toCartDto
 import com.woowa.banchan.domain.repository.CartRepository
 import javax.inject.Inject
 

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.woowa.banchan.data.local.repository
 import com.woowa.banchan.data.local.datasource.cart.CartDataSource
 import com.woowa.banchan.data.local.entity.toCart
 import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.toCartDto
 import com.woowa.banchan.domain.repository.CartRepository
 import javax.inject.Inject
 
@@ -14,4 +15,10 @@ class CartRepositoryImpl @Inject constructor(
         val list = cartDataSource.getCartList().getOrThrow()
         return runCatching { list.map { it.toCart() } }
     }
+
+    override suspend fun updateCart(cart: Cart): Result<Unit> =
+        runCatching { cartDataSource.updateCart(cart.toCartDto()) }
+
+    override suspend fun deleteCart(cart: Cart): Result<Unit> =
+        runCatching { cartDataSource.deleteCart(cart.toCartDto()) }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
@@ -32,12 +32,10 @@ class OrderRepositoryImpl @Inject constructor(
             cart.forEach { totPrice += (it.price * it.count) }
             totPrice += (if (totPrice >= freeShipping) 0 else shipping)
 
-            val orderId =
-                orderDataSource.insertNewOrder(newOrderDto(cart.size, totPrice, cart.first()))
-                    .getOrThrow()
-            orderDataSource.insertNewOrderItem(cart.map { it.toCartDto().toOrderItemDto(orderId) })
-
-            val orderDto = orderDataSource.getOrder(orderId = orderId).getOrThrow()
+            val orderDto = orderDataSource.insertNewOrderAndItem(
+                newOrderDto(cart.size, totPrice, cart.first()),
+                cart.map { it.toCartDto().toOrderItemDto(-1) }
+            ).getOrThrow()
             orderDto.toOrder()
         }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
@@ -1,11 +1,17 @@
 package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.order.OrderDataSource
+import com.woowa.banchan.data.local.entity.newOrderDto
 import com.woowa.banchan.data.local.entity.toOrder
 import com.woowa.banchan.data.local.entity.toOrderItem
+import com.woowa.banchan.data.local.entity.toOrderItemDto
+import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.domain.model.OrderItem
+import com.woowa.banchan.domain.model.toCartDto
 import com.woowa.banchan.domain.repository.OrderRepository
+import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.freeShipping
+import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.shipping
 import javax.inject.Inject
 
 class OrderRepositoryImpl @Inject constructor(
@@ -22,5 +28,20 @@ class OrderRepositoryImpl @Inject constructor(
         runCatching {
             val list = orderDataSource.getOrderDetail(orderId).getOrThrow()
             list.map { it.toOrderItem() }
+        }
+
+    override suspend fun insertCartToOrder(cart: List<Cart>): Result<Order> =
+        runCatching {
+            var totPrice = 0
+            cart.forEach { totPrice += (it.price * it.count) }
+            totPrice += (if (totPrice >= freeShipping) 0 else shipping)
+
+            val orderId =
+                orderDataSource.insertNewOrder(newOrderDto(cart.size, totPrice, cart.first()))
+                    .getOrThrow()
+            orderDataSource.insertNewOrderItem(cart.map { it.toCartDto().toOrderItemDto(orderId) })
+
+            val orderDto = orderDataSource.getOrder(orderId = orderId).getOrThrow()
+            orderDto.toOrder()
         }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
@@ -1,14 +1,10 @@
 package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.order.OrderDataSource
-import com.woowa.banchan.data.local.entity.newOrderDto
-import com.woowa.banchan.data.local.entity.toOrder
-import com.woowa.banchan.data.local.entity.toOrderItem
-import com.woowa.banchan.data.local.entity.toOrderItemDto
+import com.woowa.banchan.data.local.entity.*
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.domain.model.OrderItem
-import com.woowa.banchan.domain.model.toCartDto
 import com.woowa.banchan.domain.repository.OrderRepository
 import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.freeShipping
 import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.shipping

--- a/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
+++ b/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
@@ -1,7 +1,11 @@
 package com.woowa.banchan.di
 
+import com.woowa.banchan.domain.usecase.cart.DeleteCartUseCaseImpl
 import com.woowa.banchan.domain.usecase.cart.GetCartListUseCaseImpl
+import com.woowa.banchan.domain.usecase.cart.UpdateCartUseCaseImpl
+import com.woowa.banchan.domain.usecase.cart.inter.DeleteCartUseCase
 import com.woowa.banchan.domain.usecase.cart.inter.GetCartListUseCase
+import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
 import com.woowa.banchan.domain.usecase.food.GetBestFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.GetDetailFoodUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.GetFoodsUseCaseImpl
@@ -65,4 +69,16 @@ abstract class UseCaseModule {
     abstract fun provideGetOrderDetailUseCase(
         GetOrderDetailUseCaseImpl: GetOrderDetailUseCaseImpl
     ): GetOrderDetailUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideUpdateCartUseCase(
+        UpdateCartUseCaseImpl: UpdateCartUseCaseImpl
+    ): UpdateCartUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideDeleteCartUseCase(
+        DeleteCartUseCaseImpl: DeleteCartUseCaseImpl
+    ): DeleteCartUseCase
 }

--- a/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
+++ b/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
@@ -2,12 +2,12 @@ package com.woowa.banchan.di
 
 import com.woowa.banchan.domain.usecase.cart.DeleteCartUseCaseImpl
 import com.woowa.banchan.domain.usecase.cart.GetCartListUseCaseImpl
+import com.woowa.banchan.domain.usecase.cart.InsertCartUseCaseImpl
 import com.woowa.banchan.domain.usecase.cart.UpdateCartUseCaseImpl
 import com.woowa.banchan.domain.usecase.cart.inter.DeleteCartUseCase
-import com.woowa.banchan.domain.usecase.cart.InsertCartUseCaseImpl
 import com.woowa.banchan.domain.usecase.cart.inter.GetCartListUseCase
-import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
 import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
+import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
 import com.woowa.banchan.domain.usecase.food.GetBestFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.GetDetailFoodUseCaseImpl
 import com.woowa.banchan.domain.usecase.food.GetFoodsUseCaseImpl

--- a/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
+++ b/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
@@ -14,8 +14,10 @@ import com.woowa.banchan.domain.usecase.food.inter.GetDetailFoodUseCase
 import com.woowa.banchan.domain.usecase.food.inter.GetFoodsUseCase
 import com.woowa.banchan.domain.usecase.order.GetOrderDetailUseCaseImpl
 import com.woowa.banchan.domain.usecase.order.GetTotalOrderUseCaseImpl
+import com.woowa.banchan.domain.usecase.order.InsertCartToOrderUseCaseImpl
 import com.woowa.banchan.domain.usecase.order.inter.GetOrderDetailUseCase
 import com.woowa.banchan.domain.usecase.order.inter.GetTotalOrderUseCase
+import com.woowa.banchan.domain.usecase.order.inter.InsertCartToOrderUseCase
 import com.woowa.banchan.domain.usecase.recent.GetRecentlyViewedFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.recent.inter.GetRecentlyViewedFoodsUseCase
 import dagger.Binds
@@ -81,4 +83,10 @@ abstract class UseCaseModule {
     abstract fun provideDeleteCartUseCase(
         DeleteCartUseCaseImpl: DeleteCartUseCaseImpl
     ): DeleteCartUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideInsertCartToOrderUseCase(
+        InsertCartToOrderUseCaseImpl: InsertCartToOrderUseCaseImpl
+    ): InsertCartToOrderUseCase
 }

--- a/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
@@ -2,9 +2,9 @@ package com.woowa.banchan.domain.model
 
 class Cart(
     val hash: String,
-    val checkState: Boolean,
+    var checkState: Boolean,
     val price: Int,
-    val count: Int,
+    var count: Int,
     val title: String,
     val imageUrl: String,
 )

--- a/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
@@ -1,5 +1,7 @@
 package com.woowa.banchan.domain.model
 
+import com.woowa.banchan.data.local.entity.CartDto
+
 class Cart(
     val hash: String,
     var checkState: Boolean,
@@ -16,4 +18,13 @@ fun emptyCart(): Cart = Cart(
     0,
     "",
     "https://i.insider.com/5484d9d1eab8ea3017b17e29?width=600&format=jpeg&auto=webp"
+)
+
+fun Cart.toCartDto() = CartDto(
+    hash = hash,
+    checkState = checkState,
+    price = price,
+    count = count,
+    title = title,
+    imageUrl = imageUrl
 )

--- a/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
@@ -1,7 +1,5 @@
 package com.woowa.banchan.domain.model
 
-import com.woowa.banchan.data.local.entity.CartDto
-
 class Cart(
     val hash: String,
     var checkState: Boolean,

--- a/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
@@ -19,12 +19,3 @@ fun emptyCart(): Cart = Cart(
     "",
     "https://i.insider.com/5484d9d1eab8ea3017b17e29?width=600&format=jpeg&auto=webp"
 )
-
-fun Cart.toCartDto() = CartDto(
-    hash = hash,
-    checkState = checkState,
-    price = price,
-    count = count,
-    title = title,
-    imageUrl = imageUrl
-)

--- a/app/src/main/java/com/woowa/banchan/domain/model/Order.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Order.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.domain.model
 
+import java.io.Serializable
 import java.util.*
 
 data class Order(
@@ -10,4 +11,4 @@ data class Order(
     val price: Int,
     val title: String,
     val imageUrl: String,
-)
+) : Serializable

--- a/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
@@ -5,4 +5,8 @@ import com.woowa.banchan.domain.model.Cart
 interface CartRepository {
 
     suspend fun getCartList(): Result<List<Cart>>
+
+    suspend fun updateCart(cart: Cart): Result<Unit>
+
+    suspend fun deleteCart(cart: Cart): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/repository/OrderRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/OrderRepository.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.domain.repository
 
+import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.domain.model.OrderItem
 
@@ -7,4 +8,5 @@ interface OrderRepository {
 
     suspend fun getTotalOrderList(): Result<List<Order>>
     suspend fun getOrderDetail(orderId: Long): Result<List<OrderItem>>
+    suspend fun insertCartToOrder(cart: List<Cart>): Result<Order>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/DeleteCartUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/DeleteCartUseCaseImpl.kt
@@ -1,0 +1,23 @@
+package com.woowa.banchan.domain.usecase.cart
+
+import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.repository.CartRepository
+import com.woowa.banchan.domain.usecase.cart.inter.DeleteCartUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class DeleteCartUseCaseImpl @Inject constructor(
+    private val cartRepository: CartRepository
+) : DeleteCartUseCase {
+
+    override suspend operator fun invoke(cart: Cart): Flow<UiState<Unit>> = flow {
+        emit(UiState.Loading)
+        cartRepository.deleteCart(cart)
+            .onSuccess { emit(UiState.Success(Unit)) }
+            .onFailure { emit(UiState.Error(it.message)) }
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/UpdateCartUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/UpdateCartUseCaseImpl.kt
@@ -1,0 +1,23 @@
+package com.woowa.banchan.domain.usecase.cart
+
+import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.repository.CartRepository
+import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class UpdateCartUseCaseImpl @Inject constructor(
+    private val cartRepository: CartRepository
+) : UpdateCartUseCase {
+
+    override suspend operator fun invoke(cart: Cart): Flow<UiState<Unit>> = flow {
+        emit(UiState.Loading)
+        cartRepository.updateCart(cart)
+            .onSuccess { emit(UiState.Success(Unit)) }
+            .onFailure { emit(UiState.Error(it.message)) }
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/DeleteCartUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/DeleteCartUseCase.kt
@@ -4,7 +4,7 @@ import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
-interface DeleteCartUseCase{
+interface DeleteCartUseCase {
 
     suspend operator fun invoke(cart: Cart): Flow<UiState<Unit>>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/UpdateCartUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/UpdateCartUseCase.kt
@@ -4,7 +4,7 @@ import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
-interface DeleteCartUseCase{
+interface UpdateCartUseCase {
 
     suspend operator fun invoke(cart: Cart): Flow<UiState<Unit>>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/order/InsertCartToOrderUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/order/InsertCartToOrderUseCaseImpl.kt
@@ -1,0 +1,24 @@
+package com.woowa.banchan.domain.usecase.order
+
+import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.Order
+import com.woowa.banchan.domain.repository.OrderRepository
+import com.woowa.banchan.domain.usecase.order.inter.InsertCartToOrderUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class InsertCartToOrderUseCaseImpl @Inject constructor(
+    private val orderRepository: OrderRepository
+) : InsertCartToOrderUseCase {
+
+    override suspend operator fun invoke(cartList: List<Cart>): Flow<UiState<Order>> = flow {
+        emit(UiState.Loading)
+        orderRepository.insertCartToOrder(cartList)
+            .onSuccess { emit(UiState.Success(it)) }
+            .onFailure { emit(UiState.Error(it.message)) }
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/InsertCartToOrderUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/InsertCartToOrderUseCase.kt
@@ -1,3 +1,11 @@
 package com.woowa.banchan.domain.usecase.order.inter
 
-interface InsertCartToOrderUseCase
+import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.Order
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.flow.Flow
+
+interface InsertCartToOrderUseCase{
+
+    suspend operator fun invoke(cartList: List<Cart>): Flow<UiState<Order>>
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/InsertCartToOrderUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/order/inter/InsertCartToOrderUseCase.kt
@@ -5,7 +5,7 @@ import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
-interface InsertCartToOrderUseCase{
+interface InsertCartToOrderUseCase {
 
     suspend operator fun invoke(cartList: List<Cart>): Flow<UiState<Order>>
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
@@ -1,10 +1,13 @@
 package com.woowa.banchan.ui.cart
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Recent
+import com.woowa.banchan.domain.usecase.cart.inter.DeleteCartUseCase
 import com.woowa.banchan.domain.usecase.cart.inter.GetCartListUseCase
+import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
 import com.woowa.banchan.domain.usecase.recent.inter.GetRecentlyViewedFoodsUseCase
 import com.woowa.banchan.ui.common.livedata.SingleLiveData
 import com.woowa.banchan.ui.common.uistate.UiState
@@ -17,10 +20,14 @@ import javax.inject.Inject
 @HiltViewModel
 class CartViewModel @Inject constructor(
     private val getCartListUseCase: GetCartListUseCase,
-    private val getRecentlyViewedFoodsUseCase: GetRecentlyViewedFoodsUseCase
+    private val getRecentlyViewedFoodsUseCase: GetRecentlyViewedFoodsUseCase,
+    private val updateCartUseCase: UpdateCartUseCase,
+    private val deleteCartUseCase: DeleteCartUseCase,
 ) : ViewModel() {
 
     val fragmentTag = SingleLiveData("cart")
+
+    private val updateCartCache = mutableListOf<Pair<Cart, Boolean>>()
 
     private val _cartUiState = MutableStateFlow<UiState<List<Cart>>>(UiState.Empty)
     val cartUiState: StateFlow<UiState<List<Cart>>> get() = _cartUiState
@@ -37,5 +44,27 @@ class CartViewModel @Inject constructor(
 
     fun setFragmentTag(tag: String) {
         fragmentTag.setValue(tag)
+    }
+
+    fun updateCart() = viewModelScope.launch {
+        updateCartCache.forEach {
+            if (it.second) {
+                launch { deleteCartUseCase(it.first).collect {} }
+            } else {
+                launch { updateCartUseCase(it.first).collect {} }
+            }
+        }
+    }
+
+    fun addUpdateCartCache(cart: Cart, removeFlag: Boolean) {
+        val idx = getCartCacheIdx(cart)
+
+        if (idx == -1) updateCartCache.add(Pair(cart, removeFlag))
+        else updateCartCache[idx] = Pair(cart, removeFlag)
+    }
+
+    private fun getCartCacheIdx(cart: Cart): Int {
+        updateCartCache.forEachIndexed { index, pair -> if (pair.first.hash == cart.hash) return index }
+        return -1
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
@@ -16,7 +16,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import okhttp3.internal.wait
 import javax.inject.Inject
 
 @HiltViewModel
@@ -82,15 +81,8 @@ class CartViewModel @Inject constructor(
                     val checkedList = mutableListOf<Cart>()
                     it.data.forEach { cart -> if (cart.checkState) checkedList.add(cart) }
                     insertCartToOrderUseCase(checkedList).collect { c ->
-                        when (it) {
-                            is UiState.Success -> {
-                                _orderUiState.emit(c)
-                                checkedList.forEach { launch { deleteCartUseCase(it).collect {} } }
-                            }
-                            is UiState.Error -> _orderUiState.emit(it)
-                            is UiState.Loading -> _orderUiState.emit(it)
-                            else -> {}
-                        }
+                        _orderUiState.emit(c)
+                        checkedList.forEach { launch { deleteCartUseCase(it).collect {} } }
                     }
                 }
                 is UiState.Error -> _orderUiState.emit(it)

--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
@@ -1,13 +1,14 @@
 package com.woowa.banchan.ui.cart
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.domain.model.Recent
 import com.woowa.banchan.domain.usecase.cart.inter.DeleteCartUseCase
 import com.woowa.banchan.domain.usecase.cart.inter.GetCartListUseCase
 import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
+import com.woowa.banchan.domain.usecase.order.inter.InsertCartToOrderUseCase
 import com.woowa.banchan.domain.usecase.recent.inter.GetRecentlyViewedFoodsUseCase
 import com.woowa.banchan.ui.common.livedata.SingleLiveData
 import com.woowa.banchan.ui.common.uistate.UiState
@@ -15,6 +16,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import okhttp3.internal.wait
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,6 +25,7 @@ class CartViewModel @Inject constructor(
     private val getRecentlyViewedFoodsUseCase: GetRecentlyViewedFoodsUseCase,
     private val updateCartUseCase: UpdateCartUseCase,
     private val deleteCartUseCase: DeleteCartUseCase,
+    private val insertCartToOrderUseCase: InsertCartToOrderUseCase,
 ) : ViewModel() {
 
     val fragmentTag = SingleLiveData("cart")
@@ -34,6 +37,9 @@ class CartViewModel @Inject constructor(
 
     private val _recentUiState = MutableStateFlow<UiState<List<Recent>>>(UiState.Empty)
     val recentUiState: StateFlow<UiState<List<Recent>>> get() = _recentUiState
+
+    private val _orderUiState = MutableStateFlow<UiState<Order>>(UiState.Empty)
+    val orderUiState: StateFlow<UiState<Order>> get() = _orderUiState
 
     init {
         viewModelScope.launch {
@@ -66,5 +72,31 @@ class CartViewModel @Inject constructor(
     private fun getCartCacheIdx(cart: Cart): Int {
         updateCartCache.forEachIndexed { index, pair -> if (pair.first.hash == cart.hash) return index }
         return -1
+    }
+
+    fun addOrder() = viewModelScope.launch {
+        updateCart().join()
+        getCartListUseCase().collect {
+            when (it) {
+                is UiState.Success -> {
+                    val checkedList = mutableListOf<Cart>()
+                    it.data.forEach { cart -> if (cart.checkState) checkedList.add(cart) }
+                    insertCartToOrderUseCase(checkedList).collect { c ->
+                        when (it) {
+                            is UiState.Success -> {
+                                _orderUiState.emit(c)
+                                checkedList.forEach { launch { deleteCartUseCase(it).collect {} } }
+                            }
+                            is UiState.Error -> _orderUiState.emit(it)
+                            is UiState.Loading -> _orderUiState.emit(it)
+                            else -> {}
+                        }
+                    }
+                }
+                is UiState.Error -> _orderUiState.emit(it)
+                is UiState.Loading -> _orderUiState.emit(it)
+                else -> {}
+            }
+        }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -1,7 +1,6 @@
 package com.woowa.banchan.ui.cart.cart
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -45,17 +44,20 @@ class CartFragment : Fragment() {
         initListener()
     }
 
+    override fun onStop() {
+        viewModel.updateCart()
+        super.onStop()
+    }
+
     private fun initListener() {
         val listener = object : CartRVAdapter.CartButtonCallBackListener {
-            override fun onClickRemoveSelection() {}
+            override fun onClickCartUpdate(cart: Cart) {
+                viewModel.addUpdateCartCache(cart, removeFlag = false)
+            }
 
-            override fun onClickReleaseSelection() {}
-
-            override fun onClickCartCheckState(cart: Cart) {}
-
-            override fun onClickCartUpdateCount(cart: Cart) {}
-
-            override fun onClickCartRemove(cart: Cart) {}
+            override fun onClickCartRemove(cart: Cart) {
+                viewModel.addUpdateCartCache(cart, removeFlag = true)
+            }
 
             override fun onClickOrderButton() {}
 
@@ -77,7 +79,6 @@ class CartFragment : Fragment() {
             }.launchIn(viewLifecycleOwner.lifecycleScope)
         viewModel.recentUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
-                Log.d("Tester", "initObserve: $it")
                 when (it) {
                     is UiState.Success -> cartRVAdapter.setPreviewList(it.data)
                     is UiState.Error -> showToast(it.message)

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -1,6 +1,7 @@
 package com.woowa.banchan.ui.cart.cart
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,6 +9,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentCartBinding
 import com.woowa.banchan.domain.model.Cart
@@ -15,6 +17,7 @@ import com.woowa.banchan.ui.cart.CartViewModel
 import com.woowa.banchan.ui.cart.cart.adapter.CartRVAdapter
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.utils.showToast
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 class CartFragment : Fragment() {
@@ -71,15 +74,16 @@ class CartFragment : Fragment() {
                     is UiState.Error -> showToast(it.message)
                     else -> {}
                 }
-            }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
         viewModel.recentUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
+                Log.d("Tester", "initObserve: $it")
                 when (it) {
                     is UiState.Success -> cartRVAdapter.setPreviewList(it.data)
                     is UiState.Error -> showToast(it.message)
                     else -> {}
                 }
-            }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun initAdapter() {

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -53,7 +53,7 @@ class CartFragment : Fragment() {
 
             override fun onClickCartCheckState(cart: Cart) {}
 
-            override fun onClickCartUpdateCount(cart: Cart, count: Int) {}
+            override fun onClickCartUpdateCount(cart: Cart) {}
 
             override fun onClickCartRemove(cart: Cart) {}
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.ui.cart.cart
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -15,6 +16,7 @@ import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.ui.cart.CartViewModel
 import com.woowa.banchan.ui.cart.cart.adapter.CartRVAdapter
 import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.ui.order.detail.OrderDetailActivity
 import com.woowa.banchan.utils.showToast
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -59,7 +61,9 @@ class CartFragment : Fragment() {
                 viewModel.addUpdateCartCache(cart, removeFlag = true)
             }
 
-            override fun onClickOrderButton() {}
+            override fun onClickOrderButton() {
+                viewModel.addOrder()
+            }
 
             override fun onClickAllRecentlyViewed() {
                 viewModel.setFragmentTag(getString(R.string.fragment_recent))
@@ -81,6 +85,19 @@ class CartFragment : Fragment() {
             .onEach {
                 when (it) {
                     is UiState.Success -> cartRVAdapter.setPreviewList(it.data)
+                    is UiState.Error -> showToast(it.message)
+                    else -> {}
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+        viewModel.orderUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach {
+                when (it) {
+                    is UiState.Success -> {
+                        val intent = Intent(requireActivity(), OrderDetailActivity::class.java)
+                        intent.putExtra("order", it.data)
+                        startActivity(intent)
+                        requireActivity().finish()
+                    }
                     is UiState.Error -> showToast(it.message)
                     else -> {}
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.ui.cart.cart.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -15,6 +16,10 @@ import com.woowa.banchan.ui.cart.cart.adapter.viewholder.*
 class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
     private var recentPreviewList = listOf<Recent>()
+    private var recentPreviewViewHolder: RecentPreviewViewHolder? = null
+    private var totalPriceViewHolder: TotalPriceViewHolder? = null
+    private var cartFooterBtnViewHolder: CartFooterBtnViewHolder? = null
+
     private var totalPrice = 0
     private var listener: CartButtonCallBackListener? = null
 
@@ -41,30 +46,39 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
                 onClickCartCheckState = this@CartRVAdapter::onClickCartCheckState
                 onClickCartUpdateCount = this@CartRVAdapter::onClickCartUpdateCount
             }
-            CART_TOTAL_PRICE -> TotalPriceViewHolder(
-                ItemTotalPriceBinding.inflate(
-                    LayoutInflater.from(
-                        parent.context
-                    ), parent, false
+            CART_TOTAL_PRICE -> {
+                totalPriceViewHolder = TotalPriceViewHolder(
+                    ItemTotalPriceBinding.inflate(
+                        LayoutInflater.from(
+                            parent.context
+                        ), parent, false
+                    )
                 )
-            )
-            CART_FOOTER_BTN -> CartFooterBtnViewHolder(
-                ItemCartButtonFooterBinding.inflate(
-                    LayoutInflater.from(
-                        parent.context
-                    ), parent, false
-                )
-            ).apply {
-                onClickOrderButton = this@CartRVAdapter::onClickOrderButton
+                totalPriceViewHolder!!
             }
-            else -> RecentPreviewViewHolder(
-                ItemRecentPreviewBinding.inflate(
-                    LayoutInflater.from(
-                        parent.context
-                    ), parent, false
-                )
-            ).apply {
-                onClickAllRecentlyViewed = this@CartRVAdapter::onClickAllRecentlyViewed
+            CART_FOOTER_BTN -> {
+                cartFooterBtnViewHolder = CartFooterBtnViewHolder(
+                    ItemCartButtonFooterBinding.inflate(
+                        LayoutInflater.from(
+                            parent.context
+                        ), parent, false
+                    )
+                ).apply {
+                    onClickOrderButton = this@CartRVAdapter::onClickOrderButton
+                }
+                cartFooterBtnViewHolder!!
+            }
+            else -> {
+                recentPreviewViewHolder = RecentPreviewViewHolder(
+                    ItemRecentPreviewBinding.inflate(
+                        LayoutInflater.from(
+                            parent.context
+                        ), parent, false
+                    ),
+                ).apply {
+                    onClickAllRecentlyViewed = this@CartRVAdapter::onClickAllRecentlyViewed
+                }
+                recentPreviewViewHolder!!
             }
         }
     }
@@ -93,18 +107,27 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
     fun setPreviewList(recentItems: List<Recent>) {
         this.recentPreviewList = recentItems
+        recentPreviewViewHolder?.bind(recentPreviewList)
     }
 
     fun submitCartList(list: List<Cart>) {
         // 첫번째, 마지막, 마지막-1,마지막-2
         val newList = mutableListOf<Cart?>()
 
+        totalPrice = 0
+
         newList.add(null)
         if (list.isEmpty()) newList.add(emptyCart())
-        else list.forEach { newList.add(it) }
+        else list.forEach {
+            newList.add(it)
+            if (it.checkState) totalPrice += it.price
+            Log.d("Tester", "submitCartList: $it")
+        }
         repeat(3) { newList.add(null) }
 
         submitList(newList)
+        totalPriceViewHolder?.bind(totalPrice)
+        cartFooterBtnViewHolder?.bind(totalPrice)
     }
 
     fun setCartButtonCallBackListener(listener: CartButtonCallBackListener) {

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -31,22 +31,20 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
                     LayoutInflater.from(
                         parent.context
                     ), parent, false
-                )
-            ).apply {
-                onClickRemoveSelection = this@CartRVAdapter::onClickRemoveSelection
-                onClickReleaseSelection = this@CartRVAdapter::onClickReleaseSelection
-            }
+                ),
+                onClickRemoveSelection = { onClickRemoveSelection() },
+                onClickReleaseSelection = { onClickReleaseSelection() }
+            )
             CART_CONTENT -> CartContentViewHolder(
                 ItemCartBinding.inflate(
                     LayoutInflater.from(
                         parent.context
                     ), parent, false
-                )
-            ).apply {
-                onClickCartRemove = this@CartRVAdapter::onClickCartRemove
-                onClickCartCheckState = this@CartRVAdapter::onClickCartCheckState
-                onClickCartUpdateCount = this@CartRVAdapter::onClickCartUpdateCount
-            }
+                ),
+                onClickCartRemove = { onClickCartRemove(it) },
+                onClickCartCheckState = { onClickCartCheckState(it) },
+                onClickCartUpdateCount = { onClickCartUpdateCount(it) }
+            )
             CART_TOTAL_PRICE -> {
                 totalPriceViewHolder = TotalPriceViewHolder(
                     ItemTotalPriceBinding.inflate(
@@ -63,10 +61,9 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
                         LayoutInflater.from(
                             parent.context
                         ), parent, false
-                    )
-                ).apply {
-                    onClickOrderButton = this@CartRVAdapter::onClickOrderButton
-                }
+                    ),
+                    onClickOrderButton = { onClickOrderButton() }
+                )
                 cartFooterBtnViewHolder!!
             }
             else -> {
@@ -75,10 +72,9 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
                         LayoutInflater.from(
                             parent.context
                         ), parent, false
-                    ),
-                ).apply {
-                    onClickAllRecentlyViewed = this@CartRVAdapter::onClickAllRecentlyViewed
-                }
+                    ), onClickAllRecentlyViewed
+                    = { onClickAllRecentlyViewed() }
+                )
                 recentPreviewViewHolder!!
             }
         }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -141,26 +141,27 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
     private fun onClickRemoveSelection() {
         val tmpList = cartList.toMutableList()
-        cartList.forEach { tmpList.remove(it) }
-        submitCartList(tmpList)
-        listener?.onClickRemoveSelection()
+        tmpList.forEach { if (it.checkState) onClickCartRemove(it) }
     }
 
     private fun onClickReleaseSelection() {
-        cartList.forEach { it.checkState = false }
+        cartList.forEach {
+            if (it.checkState) {
+                it.checkState = false
+                onClickCartCheckState(it)
+            }
+        }
         notifyDataSetChanged()
-        updateTotalPrice()
-        listener?.onClickReleaseSelection()
     }
 
     private fun onClickCartCheckState(cart: Cart) {
         updateTotalPrice()
-        listener?.onClickCartCheckState(cart)
+        listener?.onClickCartUpdate(cart)
     }
 
     private fun onClickCartUpdateCount(cart: Cart) {
         updateTotalPrice()
-        listener?.onClickCartUpdateCount(cart)
+        listener?.onClickCartUpdate(cart)
     }
 
     private fun onClickCartRemove(cart: Cart) {
@@ -189,10 +190,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
     interface CartButtonCallBackListener {
 
-        fun onClickRemoveSelection()
-        fun onClickReleaseSelection()
-        fun onClickCartCheckState(cart: Cart)
-        fun onClickCartUpdateCount(cart: Cart)
+        fun onClickCartUpdate(cart: Cart)
         fun onClickCartRemove(cart: Cart)
         fun onClickOrderButton()
         fun onClickAllRecentlyViewed()

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
@@ -7,12 +7,12 @@ import com.woowa.banchan.databinding.ItemCartBinding
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.emptyCart
 
-class CartContentViewHolder(private val binding: ItemCartBinding) :
-    RecyclerView.ViewHolder(binding.root) {
-
-    var onClickCartCheckState: (cart: Cart) -> Unit = {}
-    var onClickCartUpdateCount: (cart: Cart) -> Unit = {}
-    var onClickCartRemove: (cart: Cart) -> Unit = {}
+class CartContentViewHolder(
+    private val binding: ItemCartBinding,
+    private val onClickCartCheckState: (cart: Cart) -> Unit = {},
+    private val onClickCartUpdateCount: (cart: Cart) -> Unit = {},
+    private val onClickCartRemove: (cart: Cart) -> Unit = {}
+) : RecyclerView.ViewHolder(binding.root) {
 
     private var cart = emptyCart()
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
@@ -5,13 +5,16 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemCartBinding
 import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.emptyCart
 
 class CartContentViewHolder(private val binding: ItemCartBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
     var onClickCartCheckState: (cart: Cart) -> Unit = {}
-    var onClickCartUpdateCount: (cart: Cart, count: Int) -> Unit = { _, _ -> }
+    var onClickCartUpdateCount: (cart: Cart) -> Unit = {}
     var onClickCartRemove: (cart: Cart) -> Unit = {}
+
+    private var cart = emptyCart()
 
     fun bind(cart: Cart) {
         if (cart.hash == "empty") {
@@ -20,9 +23,27 @@ class CartContentViewHolder(private val binding: ItemCartBinding) :
         } else
             binding.cart = cart
 
-        binding.layoutCheckBtn.setOnClickListener { onClickCartCheckState(cart) }
-        binding.ivMinusCount.setOnClickListener { onClickCartUpdateCount(cart, cart.count - 1) }
-        binding.ivPlusCount.setOnClickListener { onClickCartUpdateCount(cart, cart.count + 1) }
+        this.cart = cart
+        initButton()
+    }
+
+    private fun initButton() {
+
+        binding.layoutCheckBtn.setOnClickListener {
+            cart.checkState = cart.checkState.not()
+            binding.cart = cart
+            onClickCartCheckState(cart)
+        }
+        binding.ivMinusCount.setOnClickListener {
+            cart.count = if (cart.count <= 1) 1 else cart.count - 1
+            binding.cart = cart
+            onClickCartUpdateCount(cart)
+        }
+        binding.ivPlusCount.setOnClickListener {
+            cart.count++
+            binding.cart = cart
+            onClickCartUpdateCount(cart)
+        }
         binding.ivRemove.setOnClickListener { onClickCartRemove(cart) }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartFooterBtnViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartFooterBtnViewHolder.kt
@@ -4,10 +4,11 @@ import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemCartButtonFooterBinding
 import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.minimumPrice
 
-class CartFooterBtnViewHolder(private val binding: ItemCartButtonFooterBinding) :
+class CartFooterBtnViewHolder(
+    private val binding: ItemCartButtonFooterBinding,
+    private val onClickOrderButton: () -> Unit = {}
+) :
     RecyclerView.ViewHolder(binding.root) {
-
-    var onClickOrderButton: () -> Unit = {}
 
     fun bind(totalPrice: Int) {
         binding.totalPrice = totalPrice

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartFooterBtnViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartFooterBtnViewHolder.kt
@@ -2,9 +2,7 @@ package com.woowa.banchan.ui.cart.cart.adapter.viewholder
 
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemCartButtonFooterBinding
-import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.freeShipping
 import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.minimumPrice
-import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.shipping
 
 class CartFooterBtnViewHolder(private val binding: ItemCartButtonFooterBinding) :
     RecyclerView.ViewHolder(binding.root) {
@@ -12,10 +10,7 @@ class CartFooterBtnViewHolder(private val binding: ItemCartButtonFooterBinding) 
     var onClickOrderButton: () -> Unit = {}
 
     fun bind(totalPrice: Int) {
-        binding.totalPrice =
-            totalPrice +
-                    if (totalPrice >= freeShipping || totalPrice == 0) 0
-                    else shipping
+        binding.totalPrice = totalPrice
         binding.minimumPrice = minimumPrice
 
         binding.tvOrderBtn.setOnClickListener { onClickOrderButton() }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
@@ -10,7 +10,7 @@ class CheckHeaderViewHolder(private val binding: ItemCartCheckHeaderBinding) :
     var onClickReleaseSelection: () -> Unit = {}
 
     fun bind() {
-        binding.layoutUncheckBtn.setOnClickListener { onClickRemoveSelection() }
+        binding.tvRemoveSelection.setOnClickListener { onClickRemoveSelection() }
         binding.tvReleaseChecked.setOnClickListener { onClickReleaseSelection() }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
@@ -3,11 +3,13 @@ package com.woowa.banchan.ui.cart.cart.adapter.viewholder
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemCartCheckHeaderBinding
 
-class CheckHeaderViewHolder(private val binding: ItemCartCheckHeaderBinding) :
+class CheckHeaderViewHolder(
+    private val binding: ItemCartCheckHeaderBinding,
+    private val onClickRemoveSelection: () -> Unit = {},
+    private val onClickReleaseSelection: () -> Unit = {}
+) :
     RecyclerView.ViewHolder(binding.root) {
 
-    var onClickRemoveSelection: () -> Unit = {}
-    var onClickReleaseSelection: () -> Unit = {}
 
     fun bind() {
         binding.tvRemoveSelection.setOnClickListener { onClickRemoveSelection() }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentPreviewViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentPreviewViewHolder.kt
@@ -6,10 +6,11 @@ import com.woowa.banchan.databinding.ItemRecentPreviewBinding
 import com.woowa.banchan.domain.model.Recent
 import com.woowa.banchan.ui.cart.cart.adapter.RecentPreviewRVAdapter
 
-class RecentPreviewViewHolder(private val binding: ItemRecentPreviewBinding) :
+class RecentPreviewViewHolder(
+    private val binding: ItemRecentPreviewBinding,
+    private val onClickAllRecentlyViewed: () -> Unit = {}
+) :
     RecyclerView.ViewHolder(binding.root) {
-
-    var onClickAllRecentlyViewed: () -> Unit = {}
 
     fun bind(recentList: List<Recent>) {
         binding.tvEmptyNotice.isVisible = recentList.isEmpty()

--- a/app/src/main/java/com/woowa/banchan/ui/common/viewutils/TextViewUtil.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/viewutils/TextViewUtil.kt
@@ -4,7 +4,9 @@ import android.graphics.Paint
 import android.view.View
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
-import com.woowa.banchan.ui.cart.cart.CartFragment
+import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.freeShipping
+import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.minimumPrice
+import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.shipping
 import com.woowa.banchan.utils.DateUtil
 import com.woowa.banchan.utils.MoneyUtil
 import java.util.*
@@ -27,9 +29,9 @@ fun TextView.setOriginPrice(price: Int?) {
 
 @BindingAdapter("cartButtonPrice")
 fun TextView.setCartButton(price: Int) {
-    text = if (price <= 0) "최소주문금액을 확인해주세요"
+    text = if (price < minimumPrice) "최소주문금액을 확인해주세요"
     else {
-        val p = price + if (price >= CartFragment.freeShipping) 0 else CartFragment.shipping
+        val p = price + if (price >= freeShipping) 0 else shipping
         val str = MoneyUtil.getMoneyFormatString(p)
         "$str 주문하기"
     }
@@ -37,8 +39,8 @@ fun TextView.setCartButton(price: Int) {
 
 @BindingAdapter("cartFreeShippingPrice")
 fun TextView.setCartFreeShipping(price: Int) {
-    text = if (price <= 0) ""
-    else MoneyUtil.getMoneyFormatString(price) + "을 더 담으면 무료배송!"
+    text = if (price >= freeShipping) ""
+    else MoneyUtil.getMoneyFormatString(freeShipping - price) + "을 더 담으면 무료배송!"
 }
 
 @BindingAdapter("viewedDate")

--- a/app/src/main/java/com/woowa/banchan/ui/order/OrderActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/OrderActivity.kt
@@ -35,7 +35,7 @@ class OrderActivity : AppCompatActivity() {
     private fun initAdapter() {
         orderRVAdapter = OrderRVAdapter {
             val intent = Intent(this, OrderDetailActivity::class.java)
-            intent.putExtra("orderId", it.id)
+            intent.putExtra("order", it)
             startActivity(intent)
         }
         binding.rvOrder.adapter = orderRVAdapter

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/OrderDetailActivity.kt
@@ -22,8 +22,7 @@ class OrderDetailActivity : AppCompatActivity() {
     private lateinit var orderDetailRVAdapter: OrderDetailRVAdapter
 
     private val order: Order? by lazy {
-        intent.getIntExtra("orderId", -1)
-        null
+        intent.getSerializableExtra("order") as Order?
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/item_cart_button_footer.xml
+++ b/app/src/main/res/layout/item_cart_button_footer.xml
@@ -28,10 +28,10 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
             android:background="@drawable/background_button"
-            android:clickable="true"
+            android:clickable="@{(totalPrice &gt; minimumPrice) ? true : false}"
             android:elevation="5dp"
             android:enabled="@{(totalPrice &gt; minimumPrice) ? true : false}"
-            android:focusable="true"
+            android:focusable="@{(totalPrice &gt; minimumPrice) ? true : false}"
             android:gravity="center"
             android:padding="16dp"
             android:text="21,140원 주문하기"
@@ -40,10 +40,10 @@
         <TextView
             android:id="@+id/tv_free_shipping"
             style="@style/normal_14"
-            cartFreeShippingPrice="@{totalPrice}"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="18,860원을 더 담으면 무료배송!" />
+            android:text="18,860원을 더 담으면 무료배송!"
+            app:cartFreeShippingPrice="@{totalPrice}" />
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/item_cart_check_header.xml
+++ b/app/src/main/res/layout/item_cart_check_header.xml
@@ -13,7 +13,7 @@
         android:padding="16dp">
 
         <LinearLayout
-            android:id="@+id/layout_uncheck_btn"
+            android:id="@+id/tv_release_checked"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:clickable="true"
@@ -36,7 +36,7 @@
         </LinearLayout>
 
         <TextView
-            android:id="@+id/tv_release_checked"
+            android:id="@+id/tv_remove_selection"
             style="@style/normal_14"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
### ❗️ 이슈
- close #13

### 📝 구현한 내용
-  Cart Data Load 버그 수정
  - Database에서 데이터 로드 후 뷰가 갱신되지 않는 버그를 수정함
     - ViewHolder들을 따로 관리하면서 데이터 로드 시 bind를 직접 해주면서 데이터를 갱신한다.
  - 갱신되는 뷰에서 가격에 대한 계산 오류를 수정함
- Cart 버튼에 대한 DB 적용
  - 변경된 데이터들에 대한 cache를 data에 저장
  - cart 화면 이탈 시 cache의 데이터를 갱신
  - DB 데이터 갱신 및 삭제 기능 적용
- Cart 주문하기 버튼 동작 구현
  - 주문하기 버튼 동작 구현
  - insertOrder usecase 구현
  - 구현 방식에 대한 내용은 pr에 구체적으로 기재
- domain의 model에서 toDto 메소드 제거
  - domain의은 data의 dto를 몰라야한다고 정의
     - 따라서, domain에서 model이 dto로 변환되는 함수를 data entity로 이동시킴

### ❓ 고민한 내용
1. Cart Item들에 대한 Data 캐시
    - Cart화면에서 초기에 Coupang 장바구니처럼 각 뷰에 대한 기능을 바로 데이터베이스에 데이터 갱신을 하기로 했었다.
    - 하지만, 광현님과 이야기한 결과 사용자 화면에서는 실질적인 데이터 처리를 하지 말고 뷰만 바꾸는 동작을 하고,
        - 해당 화면에서 벗어날 경우 데이터 처리를 하자는 결론을 냈다.
    - 그래서 나는 viewModel에서 변경되는 데이터들을 cache로 저장하다가 onStop이 호출될 때 데이터를 갱신하게 된다.
2. Cart 주문하기 로직 구현하기
    - 아래 그림으로 표현해 보았다.
       1. DB와 Cache의 데이터 동기화
       2. 갱신된 DB에서 Cart List를 불러와서 checkState가 true인 것만 filtering한다.
       3. Order를 현재시간 기준으로 생성하고 그 OrderIdfmf 얻어온다.
       4. 받아올 OrderId와 함께 OrderItem으로 변경하고 삽입한다.
       5. 4번까지 동작 후 만들어진 order를 받아와서 view로 전달한다.
![63-3](https://user-images.githubusercontent.com/72387349/184937792-50e0459a-37eb-4b8e-a3be-5cc0ebb4ee23.jpg)

 