### PR TITLE
fix: Cart to OrderItem 삽입 시 에러 해결

### DIFF
--- a/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/CartDto.kt
@@ -26,7 +26,7 @@ fun CartDto.toCart(): Cart = Cart(
 )
 
 fun CartDto.toOrderItemDto(orderId: Long): OrderItemDto = OrderItemDto(
-    id = -1,
+    id = null,
     orderId = orderId,
     price = price,
     count = count,

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderItemDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderItemDto.kt
@@ -8,7 +8,7 @@ import com.woowa.banchan.domain.model.OrderItem
 
 @Entity(tableName = orderItemTable)
 data class OrderItemDto(
-    @PrimaryKey(autoGenerate = true) val id: Long,
+    @PrimaryKey(autoGenerate = true) val id: Long?,
     @ColumnInfo(name = "order_id") var orderId: Long,
     @ColumnInfo(name = "count") val count: Int,
     @ColumnInfo(name = "price") val price: Int,
@@ -18,7 +18,7 @@ data class OrderItemDto(
 
 fun OrderItemDto.toOrderItem(): OrderItem {
     return OrderItem(
-        id = id,
+        id = id!!,
         orderId = orderId,
         count = count,
         price = price,


### PR DESCRIPTION
### ❗️ 이슈
- close #61 

### 📝 구현한 내용
- 에러 원인
   - orderItem id를 -1로 지정해서 삽입함
   - 리스트로 전달할 때 모두 -1로 지정되다보니 primaryKey가 중복되어 삽입이 안됨
- autuGenerate가 되도록 삽입 시 id를 null로 넣어주면서 해결했다.