### PR TITLE
feat: Recently Viewed Products 아이템 추가 기능 구현 및 버그 수정

### DIFF
--- a/app/src/main/java/com/woowa/banchan/data/local/dao/RecentDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/RecentDao.kt
@@ -7,7 +7,7 @@ import com.woowa.banchan.data.local.entity.RecentDto
 @Dao
 interface RecentDao {
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(recentDto: RecentDto)
 
     @Update

--- a/app/src/main/java/com/woowa/banchan/data/local/dao/RecentDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/RecentDao.kt
@@ -16,6 +16,6 @@ interface RecentDao {
     @Delete
     fun delete(recentDto: RecentDto)
 
-    @Query("SELECT * FROM ${BanchanDataBase.recentTable}")
+    @Query("SELECT * FROM ${BanchanDataBase.recentTable} ORDER BY time DESC")
     fun getRecentList(): List<RecentDto>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSource.kt
@@ -5,4 +5,5 @@ import com.woowa.banchan.data.local.entity.RecentDto
 interface RecentDataSource {
 
     suspend fun getRecentList(): Result<List<RecentDto>>
+    suspend fun insertRecent(recentDto: RecentDto): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSourceImpl.kt
@@ -10,4 +10,7 @@ class RecentDataSourceImpl @Inject constructor(
 
     override suspend fun getRecentList(): Result<List<RecentDto>> =
         runCatching { recentDao.getRecentList() }
+
+    override suspend fun insertRecent(recentDto: RecentDto): Result<Unit> =
+        runCatching { recentDao.insert(recentDto) }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/RecentDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/RecentDto.kt
@@ -36,3 +36,13 @@ fun Recent.toFoodItem(): FoodItem = FoodItem(
     percent = ((sPrice - nPrice) * 100) / sPrice,
     title = title
 )
+
+fun Recent.toRecentDto(): RecentDto =
+    RecentDto(
+        hash,
+        time,
+        nPrice,
+        sPrice,
+        title,
+        imageUrl
+    )

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/RecentRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/RecentRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.woowa.banchan.data.local.repository
 import com.woowa.banchan.data.local.datasource.recent.RecentDataSource
 import com.woowa.banchan.data.local.entity.toRecent
 import com.woowa.banchan.domain.model.Recent
+import com.woowa.banchan.domain.model.toRecentDto
 import com.woowa.banchan.domain.repository.RecentRepository
 import javax.inject.Inject
 
@@ -14,4 +15,7 @@ class RecentRepositoryImpl @Inject constructor(
         val list = recentDataSource.getRecentList().getOrThrow()
         return runCatching { list.map { it.toRecent() } }
     }
+
+    override suspend fun insertRecent(recent: Recent): Result<Unit> =
+        runCatching { recentDataSource.insertRecent(recent.toRecentDto()) }
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/RecentRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/RecentRepositoryImpl.kt
@@ -2,8 +2,8 @@ package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.recent.RecentDataSource
 import com.woowa.banchan.data.local.entity.toRecent
+import com.woowa.banchan.data.local.entity.toRecentDto
 import com.woowa.banchan.domain.model.Recent
-import com.woowa.banchan.domain.model.toRecentDto
 import com.woowa.banchan.domain.repository.RecentRepository
 import javax.inject.Inject
 

--- a/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
+++ b/app/src/main/java/com/woowa/banchan/di/UseCaseModule.kt
@@ -23,7 +23,9 @@ import com.woowa.banchan.domain.usecase.order.inter.GetOrderDetailUseCase
 import com.woowa.banchan.domain.usecase.order.inter.GetTotalOrderUseCase
 import com.woowa.banchan.domain.usecase.order.inter.InsertCartToOrderUseCase
 import com.woowa.banchan.domain.usecase.recent.GetRecentlyViewedFoodsUseCaseImpl
+import com.woowa.banchan.domain.usecase.recent.InsertRecentlyViewedFoodsUseCaseImpl
 import com.woowa.banchan.domain.usecase.recent.inter.GetRecentlyViewedFoodsUseCase
+import com.woowa.banchan.domain.usecase.recent.inter.InsertRecentlyViewedFoodsUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -105,4 +107,10 @@ abstract class UseCaseModule {
     abstract fun provideGetEachOrderUseCase(
         GetEachOrderUseCaseImpl: GetEachOrderUseCaseImpl
     ): GetEachOrderUseCase
+
+    @Singleton
+    @Binds
+    abstract fun provideInsertRecentlyViewedFoodsUseCase(
+        InsertRecentlyViewedFoodsUseCaseImpl: InsertRecentlyViewedFoodsUseCaseImpl
+    ): InsertRecentlyViewedFoodsUseCase
 }

--- a/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
@@ -1,5 +1,7 @@
 package com.woowa.banchan.domain.model
 
+import java.util.*
+
 data class DetailItem(
     val hash: String,
     val deliveryFee: String,
@@ -21,5 +23,15 @@ data class DetailItem(
             count = totalCount,
             title = title,
             imageUrl = topImage
+        )
+
+    fun toRecent(title: String): Recent =
+        Recent(
+            hash = hash,
+            time = Date(System.currentTimeMillis()),
+            nPrice = nPrice ?: sPrice,
+            sPrice = sPrice,
+            title = title,
+            imageUrl = topImage,
         )
 }

--- a/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.domain.model
 
+import com.woowa.banchan.data.local.entity.RecentDto
 import java.util.*
 
 data class Recent(
@@ -10,3 +11,13 @@ data class Recent(
     val title: String,
     val imageUrl: String,
 )
+
+fun Recent.toRecentDto(): RecentDto =
+    RecentDto(
+        hash,
+        time,
+        nPrice,
+        sPrice,
+        title,
+        imageUrl
+    )

--- a/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.domain.model
 
-import com.woowa.banchan.data.local.entity.RecentDto
 import java.util.*
 
 data class Recent(
@@ -11,13 +10,3 @@ data class Recent(
     val title: String,
     val imageUrl: String,
 )
-
-fun Recent.toRecentDto(): RecentDto =
-    RecentDto(
-        hash,
-        time,
-        nPrice,
-        sPrice,
-        title,
-        imageUrl
-    )

--- a/app/src/main/java/com/woowa/banchan/domain/repository/RecentRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/RecentRepository.kt
@@ -5,4 +5,5 @@ import com.woowa.banchan.domain.model.Recent
 interface RecentRepository {
 
     suspend fun getRecentList(): Result<List<Recent>>
+    suspend fun insertRecent(recent: Recent): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/recent/InsertRecentlyViewedFoodsUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/recent/InsertRecentlyViewedFoodsUseCaseImpl.kt
@@ -1,0 +1,28 @@
+package com.woowa.banchan.domain.usecase.recent
+
+import com.woowa.banchan.domain.model.DetailItem
+import com.woowa.banchan.domain.repository.RecentRepository
+import com.woowa.banchan.domain.usecase.recent.inter.InsertRecentlyViewedFoodsUseCase
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class InsertRecentlyViewedFoodsUseCaseImpl @Inject constructor(
+    private val recentRepository: RecentRepository
+) : InsertRecentlyViewedFoodsUseCase {
+
+    override suspend fun invoke(
+        detailItem: DetailItem,
+        title: String,
+        totalCount: Int
+    ): Flow<UiState<Unit>> =
+        flow {
+            emit(UiState.Loading)
+            recentRepository.insertRecent(detailItem.toRecent(title))
+                .onSuccess { emit(UiState.Success(it)) }
+                .onFailure { emit(UiState.Error(it.message)) }
+        }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/recent/inter/InsertRecentlyViewedFoodsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/recent/inter/InsertRecentlyViewedFoodsUseCase.kt
@@ -1,0 +1,10 @@
+package com.woowa.banchan.domain.usecase.recent.inter
+
+import com.woowa.banchan.domain.model.DetailItem
+import com.woowa.banchan.ui.common.uistate.UiState
+import kotlinx.coroutines.flow.Flow
+
+interface InsertRecentlyViewedFoodsUseCase {
+
+    suspend operator fun invoke(detailItem: DetailItem, title: String, totalCount: Int): Flow<UiState<Unit>>
+}

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentPreviewViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentPreviewViewHolder.kt
@@ -12,10 +12,14 @@ class RecentPreviewViewHolder(
 ) :
     RecyclerView.ViewHolder(binding.root) {
 
+    val maxCount = 7
+
     fun bind(recentList: List<Recent>) {
         binding.tvEmptyNotice.isVisible = recentList.isEmpty()
+        val list = mutableListOf<Recent>()
+        recentList.forEachIndexed { index, recent -> if (index < maxCount) list.add(recent) }
         val adapter = RecentPreviewRVAdapter()
-        adapter.submitList(recentList)
+        adapter.submitList(list)
         binding.rvRecentPreview.adapter = adapter
         binding.tvAllRecent.setOnClickListener { onClickAllRecentlyViewed() }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailActivity.kt
@@ -45,7 +45,7 @@ class DetailActivity : AppCompatActivity() {
     private fun getIntentValues() {
         title = intent.getStringExtra("title")!!
         hash = intent.getStringExtra("hash")!!
-        if(title == null || hash == null) finish()
+        if (title == null || hash == null) finish()
     }
 
     private fun initBinding() {
@@ -70,6 +70,7 @@ class DetailActivity : AppCompatActivity() {
                     val detailRVAdapter = DetailRVAdapter(state.data.detailSection)
                     binding.rvDetail.adapter = detailRVAdapter
                     detailRVAdapter.notifyDataSetChanged()
+                    viewModel.insertRecentlyViewed(title!!, totalCount)
                 } else if (state is UiState.Error) {
 
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
@@ -5,25 +5,29 @@ import androidx.lifecycle.viewModelScope
 import com.woowa.banchan.domain.model.DetailItem
 import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
 import com.woowa.banchan.domain.usecase.food.inter.GetDetailFoodUseCase
+import com.woowa.banchan.domain.usecase.recent.inter.InsertRecentlyViewedFoodsUseCase
 import com.woowa.banchan.ui.common.event.SingleEvent
 import com.woowa.banchan.ui.common.uistate.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class DetailViewModel @Inject constructor(
     private val getDetailFoodUseCase: GetDetailFoodUseCase,
-    private val insertCartUseCase: InsertCartUseCase
+    private val insertCartUseCase: InsertCartUseCase,
+    private val insertRecentlyViewedFoodsUseCase: InsertRecentlyViewedFoodsUseCase
 ) : ViewModel() {
 
     private var _detailUiState = MutableStateFlow<UiState<DetailItem>>(UiState.Empty)
     val detailUiState: StateFlow<UiState<DetailItem>> get() = _detailUiState.asStateFlow()
 
-    private val _insertionUiState = MutableStateFlow<SingleEvent<UiState<Unit>>>(SingleEvent(UiState.Empty))
+    private val _insertionUiState =
+        MutableStateFlow<SingleEvent<UiState<Unit>>>(SingleEvent(UiState.Empty))
     val insertionUiState: StateFlow<SingleEvent<UiState<Unit>>> get() = _insertionUiState.asStateFlow()
 
     fun getDetailFood(hash: String) {
@@ -43,6 +47,16 @@ class DetailViewModel @Inject constructor(
             ).collect { uiState ->
                 _insertionUiState.emit(SingleEvent(uiState))
             }
+        }
+    }
+
+    fun insertRecentlyViewed(title: String, totalCount: Int) {
+        viewModelScope.launch {
+            insertRecentlyViewedFoodsUseCase(
+                (detailUiState.value as UiState.Success).data,
+                title,
+                totalCount
+            ).collect()
         }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/utils/DateUtil.kt
+++ b/app/src/main/java/com/woowa/banchan/utils/DateUtil.kt
@@ -7,11 +7,11 @@ object DateUtil {
 
     private val format: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss")
         .apply { timeZone = TimeZone.getTimeZone("Aisa/Seoul") }
-    private val currentDate: Date by lazy { Date(System.currentTimeMillis()) }
 
     fun getUpdateDate(date: Date): String {
+        val currentTime = System.currentTimeMillis()
 
-        val diff: Long = currentDate.time - date.time
+        val diff: Long = currentTime - date.time
         val seconds = diff / 1000
         val minutes = seconds / 60
         val hours = minutes / 60


### PR DESCRIPTION
### ❗️ 이슈
- close #66 

### 📝 구현한 내용
- 상품 Recently Viewed Products 기능 구현
  - 상품 조회 시 최근 본 상품 테이블 항목에 추가 기능 구현
  - 만일 기존에 데이터가 있다면 새로운 시간대로 갱신한다.
- Recently Viewed Products 정렬
  - Cart View에서 최대 7개 항목만 시간순으로 보여준다.
  - 전체 불러올 때 시간순서대로 불러온다.
- Recently Viewed Products 시간 오류 해결
  - 최근 본 시간이 -초가 되는 것을 확인
  - 이는 앱이 실행할 때 DateUtil에서 초기화된 시간을 기준으로 확인하기 때문에 그 이후에 보는 아이템들에 대해서 미래에 확인한 것으로 판단이 됨
  - 이를 getUpdateDate를 얻을 때마다 기기 시간을 얻어와 갱신하여 해결함