### PR TITLE
refactor: Recent Table nPrice nullable 처리

### DIFF
--- a/app/src/main/java/com/woowa/banchan/data/local/entity/RecentDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/RecentDto.kt
@@ -12,7 +12,7 @@ import java.util.*
 data class RecentDto(
     @PrimaryKey val hash: String,
     @ColumnInfo(name = "time") val time: Date,
-    @ColumnInfo(name = "n_price") val nPrice: Int,
+    @ColumnInfo(name = "n_price") val nPrice: Int?,
     @ColumnInfo(name = "s_price") val sPrice: Int,
     @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "image_url") val imageUrl: String,
@@ -33,7 +33,8 @@ fun Recent.toFoodItem(): FoodItem = FoodItem(
     image = imageUrl,
     nPrice = nPrice,
     sPrice = sPrice,
-    percent = ((sPrice - nPrice) * 100) / sPrice,
+    percent = if (nPrice == null) null else (((sPrice - nPrice) * 100) / sPrice),
+    //((sPrice - nPrice) * 100) / sPrice,
     title = title
 )
 

--- a/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
@@ -29,7 +29,7 @@ data class DetailItem(
         Recent(
             hash = hash,
             time = Date(System.currentTimeMillis()),
-            nPrice = nPrice ?: sPrice,
+            nPrice = nPrice,
             sPrice = sPrice,
             title = title,
             imageUrl = topImage,

--- a/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
@@ -5,7 +5,7 @@ import java.util.*
 data class Recent(
     val hash: String,
     val time: Date,
-    val nPrice: Int,
+    val nPrice: Int?,
     val sPrice: Int,
     val title: String,
     val imageUrl: String,


### PR DESCRIPTION
### ❗️ 이슈
- close #71 

### 📝 구현한 내용
- api에서 받아오는 데이터의 nPrice는 nullable하다.
- 하지만 여기에선 non-null이기에 api에 맞추어 nullable로 처리한다.
- recently view에서 nPrice가 null이면 원본가격 텍스트를 보여주지 않는다.