### PR TITLE
feat: Detail 기능 추가

### DIFF
--- a/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
@@ -36,7 +36,7 @@ data class DetailItem(
         )
 }
 
-fun emptyDetailItem() : DetailItem =
+fun emptyDetailItem(): DetailItem =
     DetailItem(
         "",
         "",

--- a/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/DetailItem.kt
@@ -35,3 +35,18 @@ data class DetailItem(
             imageUrl = topImage,
         )
 }
+
+fun emptyDetailItem() : DetailItem =
+    DetailItem(
+        "",
+        "",
+        "",
+        emptyList(),
+        "",
+        0,
+        0,
+        0,
+        "",
+        emptyList(),
+        ""
+    )

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/UpdateCartUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/UpdateCartUseCaseImpl.kt
@@ -1,6 +1,7 @@
 package com.woowa.banchan.domain.usecase.cart
 
 import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.DetailItem
 import com.woowa.banchan.domain.repository.CartRepository
 import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
 import com.woowa.banchan.ui.common.uistate.UiState
@@ -17,6 +18,13 @@ class UpdateCartUseCaseImpl @Inject constructor(
     override suspend operator fun invoke(cart: Cart): Flow<UiState<Unit>> = flow {
         emit(UiState.Loading)
         cartRepository.updateCart(cart)
+            .onSuccess { emit(UiState.Success(Unit)) }
+            .onFailure { emit(UiState.Error(it.message)) }
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun invoke(detailItem: DetailItem, title: String, totalCount: Int): Flow<UiState<Unit>> = flow {
+        emit(UiState.Loading)
+        cartRepository.updateCart(detailItem.toCart(title, totalCount, true))
             .onSuccess { emit(UiState.Success(Unit)) }
             .onFailure { emit(UiState.Error(it.message)) }
     }.flowOn(Dispatchers.IO)

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/UpdateCartUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/UpdateCartUseCase.kt
@@ -1,10 +1,13 @@
 package com.woowa.banchan.domain.usecase.cart.inter
 
 import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.DetailItem
 import com.woowa.banchan.ui.common.uistate.UiState
 import kotlinx.coroutines.flow.Flow
 
 interface UpdateCartUseCase {
 
     suspend operator fun invoke(cart: Cart): Flow<UiState<Unit>>
+    suspend operator fun invoke(detailItem: DetailItem, title: String, totalCount: Int): Flow<UiState<Unit>>
+
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
@@ -1,5 +1,7 @@
 package com.woowa.banchan.ui.common.event
 
+import androidx.lifecycle.MutableLiveData
+
 open class SingleEvent<out T>(private val content: T) {
 
     var hasBeenHandled = false
@@ -21,4 +23,12 @@ open class SingleEvent<out T>(private val content: T) {
      * Returns the content, even if it's already been handled.
      */
     fun peekContent(): T = content
+}
+
+fun MutableLiveData<SingleEvent<Unit>>.emit() {
+    value = SingleEvent(Unit)
+}
+
+fun<T> MutableLiveData<SingleEvent<T>>.emit(data: T) {
+    value = SingleEvent(data)
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
@@ -38,6 +38,6 @@ fun MutableLiveData<SingleEvent<Unit>>.emit() {
     value = SingleEvent(Unit)
 }
 
-fun<T> MutableLiveData<SingleEvent<T>>.emit(data: T) {
+fun <T> MutableLiveData<SingleEvent<T>>.emit(data: T) {
     value = SingleEvent(data)
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
@@ -1,6 +1,7 @@
 package com.woowa.banchan.ui.common.event
 
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 
 open class SingleEvent<out T>(private val content: T) {
 
@@ -23,6 +24,14 @@ open class SingleEvent<out T>(private val content: T) {
      * Returns the content, even if it's already been handled.
      */
     fun peekContent(): T = content
+}
+
+class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<SingleEvent<T>> {
+    override fun onChanged(event: SingleEvent<T>?) {
+        event?.getContentIfNotHandled()?.let { value ->
+            onEventUnhandledContent(value)
+        }
+    }
 }
 
 fun MutableLiveData<SingleEvent<Unit>>.emit() {

--- a/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/event/SingleEvent.kt
@@ -34,10 +34,10 @@ class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Obser
     }
 }
 
-fun MutableLiveData<SingleEvent<Unit>>.emit() {
+fun MutableLiveData<SingleEvent<Unit>>.setEvent() {
     value = SingleEvent(Unit)
 }
 
-fun <T> MutableLiveData<SingleEvent<T>>.emit(data: T) {
+fun <T> MutableLiveData<SingleEvent<T>>.setEvent(data: T) {
     value = SingleEvent(data)
 }

--- a/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.ui.detail
 
-import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -16,7 +15,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentCartUpdateBinding
-import com.woowa.banchan.ui.cart.CartActivity
+import com.woowa.banchan.ui.common.event.EventObserver
 import com.woowa.banchan.ui.common.popup.CartCompleteFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.utils.showToast
@@ -65,6 +64,10 @@ class CartUpdateFragment : DialogFragment() {
                     showToast(state.message)
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)
+
+        viewModel.cancelClickEvent.observe(viewLifecycleOwner, EventObserver {
+            dismiss()
+        })
     }
 
 }

--- a/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
@@ -66,7 +66,6 @@ class CartUpdateFragment : DialogFragment() {
     private fun initObserver() {
         viewModel.updateUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
-                Log.d("Test", it.toString())
                 val state = it.getContentIfNotHandled()
                 if (state is UiState.Success) {
                     parentFragmentManager.commit { remove(this@CartUpdateFragment) }

--- a/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
@@ -3,14 +3,15 @@ package com.woowa.banchan.ui.detail
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
@@ -19,14 +20,16 @@ import com.woowa.banchan.ui.common.event.EventObserver
 import com.woowa.banchan.ui.common.popup.CartCompleteFragment
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.utils.showToast
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
+@AndroidEntryPoint
 class CartUpdateFragment : DialogFragment() {
 
     private lateinit var binding: FragmentCartUpdateBinding
 
-    private val viewModel: DetailViewModel by viewModels()
+    private val viewModel: DetailViewModel by activityViewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_cart_update, container, false)
@@ -36,8 +39,16 @@ class CartUpdateFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initBinding()
         initButtonSetting()
         initObserver()
+    }
+
+    private fun initBinding() {
+        binding.apply {
+            vm = viewModel
+            lifecycleOwner = viewLifecycleOwner
+        }
     }
 
     private fun initDialog() {
@@ -46,7 +57,7 @@ class CartUpdateFragment : DialogFragment() {
     }
 
     private fun initButtonSetting() {
-        binding.tvConfirm.setOnClickListener {  }
+        binding.tvConfirm.setOnClickListener { }
         binding.tvCancel.setOnClickListener {
             dismiss()
         }
@@ -55,12 +66,12 @@ class CartUpdateFragment : DialogFragment() {
     private fun initObserver() {
         viewModel.updateUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
+                Log.d("Test", it.toString())
                 val state = it.getContentIfNotHandled()
-                if(state is UiState.Success) {
+                if (state is UiState.Success) {
                     parentFragmentManager.commit { remove(this@CartUpdateFragment) }
                     CartCompleteFragment().show(parentFragmentManager, getString(R.string.fragment_cart_update))
-                }
-                else if (state is UiState.Error) {
+                } else if (state is UiState.Error) {
                     showToast(state.message)
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/CartUpdateFragment.kt
@@ -1,0 +1,70 @@
+package com.woowa.banchan.ui.detail
+
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.commit
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.woowa.banchan.R
+import com.woowa.banchan.databinding.FragmentCartUpdateBinding
+import com.woowa.banchan.ui.cart.CartActivity
+import com.woowa.banchan.ui.common.popup.CartCompleteFragment
+import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.utils.showToast
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+class CartUpdateFragment : DialogFragment() {
+
+    private lateinit var binding: FragmentCartUpdateBinding
+
+    private val viewModel: DetailViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_cart_update, container, false)
+        initDialog()
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initButtonSetting()
+        initObserver()
+    }
+
+    private fun initDialog() {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
+    }
+
+    private fun initButtonSetting() {
+        binding.tvConfirm.setOnClickListener {  }
+        binding.tvCancel.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    private fun initObserver() {
+        viewModel.updateUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach {
+                val state = it.getContentIfNotHandled()
+                if(state is UiState.Success) {
+                    parentFragmentManager.commit { remove(this@CartUpdateFragment) }
+                    CartCompleteFragment().show(parentFragmentManager, getString(R.string.fragment_cart_update))
+                }
+                else if (state is UiState.Error) {
+                    showToast(state.message)
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+}

--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailActivity.kt
@@ -85,7 +85,14 @@ class DetailActivity : AppCompatActivity() {
                         getString(R.string.fragment_cart_complete)
                     )
                 } else if (state is UiState.Error) {
-                    showToast(state.message)
+                    if (state.message?.substring(0, 6) == "UNIQUE") {
+                        CartUpdateFragment().show(
+                            supportFragmentManager,
+                            getString(R.string.fragment_cart_update)
+                        )
+                    } else {
+                        showToast(state.message)
+                    }
                 }
             }.launchIn(lifecycleScope)
 

--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
@@ -1,5 +1,7 @@
 package com.woowa.banchan.ui.detail
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woowa.banchan.domain.model.DetailItem
@@ -7,6 +9,8 @@ import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
 import com.woowa.banchan.domain.usecase.food.inter.GetDetailFoodUseCase
 import com.woowa.banchan.domain.usecase.recent.inter.InsertRecentlyViewedFoodsUseCase
 import com.woowa.banchan.ui.common.event.SingleEvent
+import com.woowa.banchan.ui.common.event.emit
+import com.woowa.banchan.ui.common.livedata.SingleLiveData
 import com.woowa.banchan.ui.common.uistate.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,6 +33,12 @@ class DetailViewModel @Inject constructor(
     private val _insertionUiState =
         MutableStateFlow<SingleEvent<UiState<Unit>>>(SingleEvent(UiState.Empty))
     val insertionUiState: StateFlow<SingleEvent<UiState<Unit>>> get() = _insertionUiState.asStateFlow()
+
+    private val _cartClickEvent = MutableLiveData<SingleEvent<Unit>>()
+    val cartClickEvent: LiveData<SingleEvent<Unit>> get() = _cartClickEvent
+
+    private val _userClickEvent = MutableLiveData<SingleEvent<Unit>>()
+    val userClickEvent: LiveData<SingleEvent<Unit>> get() = _userClickEvent
 
     fun getDetailFood(hash: String) {
         viewModelScope.launch {
@@ -58,5 +68,13 @@ class DetailViewModel @Inject constructor(
                 totalCount
             ).collect()
         }
+    }
+
+    fun setCartClickEvent() {
+        _cartClickEvent.emit()
+    }
+
+    fun setUserClickEvent() {
+        _userClickEvent.emit()
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.DetailItem
+import com.woowa.banchan.domain.model.emptyDetailItem
 import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
+import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
 import com.woowa.banchan.domain.usecase.food.inter.GetDetailFoodUseCase
 import com.woowa.banchan.domain.usecase.recent.inter.InsertRecentlyViewedFoodsUseCase
 import com.woowa.banchan.ui.common.event.SingleEvent
@@ -24,21 +27,32 @@ import javax.inject.Inject
 class DetailViewModel @Inject constructor(
     private val getDetailFoodUseCase: GetDetailFoodUseCase,
     private val insertCartUseCase: InsertCartUseCase,
-    private val insertRecentlyViewedFoodsUseCase: InsertRecentlyViewedFoodsUseCase
+    private val insertRecentlyViewedFoodsUseCase: InsertRecentlyViewedFoodsUseCase,
+    private val updateCartUseCase: UpdateCartUseCase
 ) : ViewModel() {
 
     private var _detailUiState = MutableStateFlow<UiState<DetailItem>>(UiState.Empty)
     val detailUiState: StateFlow<UiState<DetailItem>> get() = _detailUiState.asStateFlow()
 
-    private val _insertionUiState =
-        MutableStateFlow<SingleEvent<UiState<Unit>>>(SingleEvent(UiState.Empty))
+    private val _insertionUiState = MutableStateFlow<SingleEvent<UiState<Unit>>>(SingleEvent(UiState.Empty))
     val insertionUiState: StateFlow<SingleEvent<UiState<Unit>>> get() = _insertionUiState.asStateFlow()
+
+    private val _updateUiState = MutableStateFlow<SingleEvent<UiState<Unit>>>(SingleEvent(UiState.Empty))
+    val updateUiState: StateFlow<SingleEvent<UiState<Unit>>> get() = _updateUiState.asStateFlow()
 
     private val _cartClickEvent = MutableLiveData<SingleEvent<Unit>>()
     val cartClickEvent: LiveData<SingleEvent<Unit>> get() = _cartClickEvent
 
     private val _userClickEvent = MutableLiveData<SingleEvent<Unit>>()
     val userClickEvent: LiveData<SingleEvent<Unit>> get() = _userClickEvent
+
+    private val _updateClickEvent = MutableLiveData<SingleEvent<Unit>>()
+    val updateClickEvent: LiveData<SingleEvent<Unit>> get() = _updateClickEvent
+
+    var sPrice = MutableLiveData(0)
+    var totalCount = MutableLiveData(1)
+    var title = MutableLiveData("")
+    var detailItem = MutableLiveData(emptyDetailItem())
 
     fun getDetailFood(hash: String) {
         viewModelScope.launch {
@@ -48,12 +62,12 @@ class DetailViewModel @Inject constructor(
         }
     }
 
-    fun insertCart(title: String, totalCount: Int) {
+    fun insertCart(title: String) {
         viewModelScope.launch {
             insertCartUseCase.insertCart(
                 (detailUiState.value as UiState.Success).data,
                 title,
-                totalCount
+                totalCount.value!!
             ).collect { uiState ->
                 _insertionUiState.emit(SingleEvent(uiState))
             }
@@ -77,4 +91,5 @@ class DetailViewModel @Inject constructor(
     fun setUserClickEvent() {
         _userClickEvent.emit()
     }
+
 }

--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
@@ -11,7 +11,7 @@ import com.woowa.banchan.domain.usecase.cart.inter.UpdateCartUseCase
 import com.woowa.banchan.domain.usecase.food.inter.GetDetailFoodUseCase
 import com.woowa.banchan.domain.usecase.recent.inter.InsertRecentlyViewedFoodsUseCase
 import com.woowa.banchan.ui.common.event.SingleEvent
-import com.woowa.banchan.ui.common.event.emit
+import com.woowa.banchan.ui.common.event.setEvent
 import com.woowa.banchan.ui.common.uistate.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -83,15 +83,15 @@ class DetailViewModel @Inject constructor(
     }
 
     fun setCartClickEvent() {
-        _cartClickEvent.emit()
+        _cartClickEvent.setEvent()
     }
 
     fun setUserClickEvent() {
-        _userClickEvent.emit()
+        _userClickEvent.setEvent()
     }
 
     fun setCancelClickEvent() {
-        _cancelClickEvent.emit()
+        _cancelClickEvent.setEvent()
     }
 
     fun setUpdateClickEvent() {

--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.DetailItem
 import com.woowa.banchan.domain.model.emptyDetailItem
 import com.woowa.banchan.domain.usecase.cart.inter.InsertCartUseCase
@@ -13,7 +12,6 @@ import com.woowa.banchan.domain.usecase.food.inter.GetDetailFoodUseCase
 import com.woowa.banchan.domain.usecase.recent.inter.InsertRecentlyViewedFoodsUseCase
 import com.woowa.banchan.ui.common.event.SingleEvent
 import com.woowa.banchan.ui.common.event.emit
-import com.woowa.banchan.ui.common.livedata.SingleLiveData
 import com.woowa.banchan.ui.common.uistate.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,8 +44,8 @@ class DetailViewModel @Inject constructor(
     private val _userClickEvent = MutableLiveData<SingleEvent<Unit>>()
     val userClickEvent: LiveData<SingleEvent<Unit>> get() = _userClickEvent
 
-    private val _updateClickEvent = MutableLiveData<SingleEvent<Unit>>()
-    val updateClickEvent: LiveData<SingleEvent<Unit>> get() = _updateClickEvent
+    private val _cancelClickEvent = MutableLiveData<SingleEvent<Unit>>()
+    val cancelClickEvent: LiveData<SingleEvent<Unit>> get() = _cancelClickEvent
 
     var sPrice = MutableLiveData(0)
     var totalCount = MutableLiveData(1)
@@ -92,4 +90,15 @@ class DetailViewModel @Inject constructor(
         _userClickEvent.emit()
     }
 
+    fun setCancelClickEvent() {
+        _cancelClickEvent.emit()
+    }
+
+    fun setUpdateClickEvent() {
+        viewModelScope.launch {
+            updateCartUseCase(detailItem.value!!, title.value!!, totalCount.value!!).collect { uiState ->
+                _updateUiState.emit(SingleEvent(uiState))
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseFragment.kt
@@ -2,7 +2,6 @@ package com.woowa.banchan.ui.home
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseViewModel.kt
@@ -16,6 +16,7 @@ abstract class HomeBaseViewModel : ViewModel() {
 
     @Inject
     lateinit var deleteCartUseCase: DeleteCartUseCase
+
     @Inject
     lateinit var getFoodsUseCase: GetFoodsUseCase
 

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -21,6 +21,10 @@
             name="count"
             type="Integer" />
 
+        <variable
+            name="vm"
+            type="com.woowa.banchan.ui.detail.DetailViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -32,6 +36,8 @@
             android:id="@+id/ctb_toolbar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            app:onClickCartIcon="@{vm.setCartClickEvent}"
+            app:onClickUserIcon="@{vm.setUserClickEvent}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -6,22 +6,6 @@
     <data>
 
         <variable
-            name="detail"
-            type="com.woowa.banchan.domain.model.DetailItem" />
-
-        <variable
-            name="title"
-            type="String" />
-
-        <variable
-            name="price"
-            type="Integer" />
-
-        <variable
-            name="count"
-            type="Integer" />
-
-        <variable
             name="vm"
             type="com.woowa.banchan.ui.detail.DetailViewModel" />
 
@@ -95,7 +79,7 @@
                         android:layout_height="wrap_content"
                         android:paddingTop="32dp"
                         android:paddingBottom="8dp"
-                        android:text="@{title}"
+                        android:text="@{vm.title}"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
                         tools:text="오리 주물럭_반조리" />
@@ -106,7 +90,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:paddingBottom="8dp"
-                        android:text="@{detail.productDescription}"
+                        android:text="@{vm.detailItem.productDescription}"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/tv_title"
                         tools:text="감칠맛 나는 매콤한 양념" />
@@ -120,7 +104,7 @@
                         android:textStyle="bold"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/tv_content"
-                        app:percent="@{detail.percent}"
+                        app:percent="@{vm.detailItem.percent}"
                         tools:text="10%" />
 
                     <TextView
@@ -131,7 +115,7 @@
                         android:paddingEnd="8dp"
                         app:layout_constraintStart_toEndOf="@id/tv_percent"
                         app:layout_constraintTop_toBottomOf="@id/tv_content"
-                        app:price="@{detail.sPrice}"
+                        app:price="@{vm.detailItem.sPrice}"
                         tools:text="12,640원" />
 
                     <TextView
@@ -141,7 +125,7 @@
                         android:layout_height="wrap_content"
                         app:layout_constraintBottom_toBottomOf="@id/tv_s_price"
                         app:layout_constraintStart_toEndOf="@id/tv_s_price"
-                        app:originPrice="@{detail.nPrice}"
+                        app:originPrice="@{vm.detailItem.nPrice}"
                         tools:text="15,800원" />
 
                     <View
@@ -168,7 +152,7 @@
                         android:id="@+id/tv_point"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:text="@{detail.point}"
+                        android:text="@{vm.detailItem.point}"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toEndOf="@id/tv_point_label"
                         app:layout_constraintTop_toTopOf="@id/tv_point_label"
@@ -188,7 +172,7 @@
                         android:id="@+id/tv_delivery_info"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:text="@{detail.deliveryInfo}"
+                        android:text="@{vm.detailItem.deliveryInfo}"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toEndOf="@id/tv_delivery_info_label"
                         app:layout_constraintTop_toTopOf="@id/tv_delivery_info_label"
@@ -208,7 +192,7 @@
                         android:id="@+id/tv_delivery_fee"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:text="@{detail.deliveryFee}"
+                        android:text="@{vm.detailItem.deliveryFee}"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toEndOf="@id/tv_delivery_fee_label"
                         app:layout_constraintTop_toTopOf="@id/tv_delivery_fee_label"
@@ -242,7 +226,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:paddingHorizontal="24dp"
-                        android:text="@{Integer.toString(count)}"
+                        android:text="@{Integer.toString(vm.totalCount)}"
                         app:layout_constraintBottom_toBottomOf="@id/iv_plus"
                         app:layout_constraintEnd_toStartOf="@id/iv_plus"
                         app:layout_constraintTop_toTopOf="@id/iv_plus" />
@@ -298,7 +282,7 @@
                         android:layout_marginTop="32dp"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/view_divider3"
-                        app:price="@{price}"
+                        app:price="@{vm.sPrice * vm.totalCount}"
                         tools:text="12,640원" />
 
                     <Button

--- a/app/src/main/res/layout/fragment_cart_update.xml
+++ b/app/src/main/res/layout/fragment_cart_update.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.woowa.banchan.ui.detail.DetailViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/background_dialog"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tv_cart_update_title"
+            style="@style/normal_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cart_update_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_confirm"
+            style="@style/bold_accent_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/update_confirm"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_cart_update_title" />
+
+        <TextView
+            android:id="@+id/tv_cancel"
+            style="@style/bold_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingEnd="24dp"
+            android:text="@string/update_cancel"
+            app:layout_constraintEnd_toStartOf="@id/tv_confirm"
+            app:layout_constraintTop_toTopOf="@id/tv_confirm" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_cart_update.xml
+++ b/app/src/main/res/layout/fragment_cart_update.xml
@@ -41,6 +41,7 @@
             android:layout_height="wrap_content"
             android:paddingEnd="24dp"
             android:text="@string/update_cancel"
+            android:onClick="@{() -> vm.setCancelClickEvent()}"
             app:layout_constraintEnd_toStartOf="@id/tv_confirm"
             app:layout_constraintTop_toTopOf="@id/tv_confirm" />
 

--- a/app/src/main/res/layout/fragment_cart_update.xml
+++ b/app/src/main/res/layout/fragment_cart_update.xml
@@ -30,6 +30,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
             android:text="@string/update_confirm"
+            android:onClick="@{() -> vm.setUpdateClickEvent()}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_cart_update_title" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="fragment_side">side</string>
     <string name="fragment_cart_add">cartAdd</string>
     <string name="fragment_cart_complete">cartComplete</string>
+    <string name="fragment_cart_update">cartUpdate</string>
     <string name="badge">기획전</string>
 
     <!--Header Title-->
@@ -37,4 +38,7 @@
     <string name="dlg_title">선택한 상품이 장바구니에 담겼습니다.</string>
     <string name="continue_shopping">계속 쇼핑하기</string>
     <string name="cart_confirm">장바구니 확인</string>
+    <string name="cart_update_title">이미 장바구니에 있습니다. 변경하시겠습니까?</string>
+    <string name="update_cancel">취소</string>
+    <string name="update_confirm">확인</string>
 </resources>


### PR DESCRIPTION
### ❗️ 이슈
- close #78 

### 📝 구현한 내용
- Detail 화면에서 장바구니, 유저 아이콘 클릭시 화면 이동
- 중복 아이템 삽입 처리
- 일부 클릭 이벤트 ViewModel로 이전 ( #83 View에서 직접 클릭이벤트를 처리하지 않도록 모두 ViewModel로 이전해야 해서 우선은 지금 구현하는 기능이라도 전과 다르게 ViewModel에 클릭 이벤트를 위임하였습니다.

### ❓ 고민한 내용
- 이미 있는 아이템의 경우 어떻게 처리하면 좋을까 고민하였습니다.
  - 이미 있는 경우 삽입이 안 되게 하면 그만이긴 하지만, 사용자의 편의를 위해 수정할 수 있으면 좋을 것 같다고 생각했습니다.

그래서 이미 존재할 경우

<img width="364" alt="image" src="https://user-images.githubusercontent.com/77563227/185741101-152681a5-2029-4075-8199-33c0b51729f4.png">

위와 같이 수정할 수 있는 다이얼로그를 띄어주었습니다!
