### PR TITLE
feat: Cart 버그 수정 및 전체 선택 기능 구현

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -17,24 +17,30 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
     private var recentPreviewList = listOf<Recent>()
     private var cartList = mutableListOf<Cart>()
 
+    private var checkHeaderViewHolder: CheckHeaderViewHolder? = null
     private var recentPreviewViewHolder: RecentPreviewViewHolder? = null
     private var totalPriceViewHolder: TotalPriceViewHolder? = null
     private var cartFooterBtnViewHolder: CartFooterBtnViewHolder? = null
 
     private var totalPrice = 0
+    private var checkStateFlag = 0
     private var listener: CartButtonCallBackListener? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
-            CART_CHECK_HEADER -> CheckHeaderViewHolder(
-                ItemCartCheckHeaderBinding.inflate(
-                    LayoutInflater.from(
-                        parent.context
-                    ), parent, false
-                ),
-                onClickRemoveSelection = { onClickRemoveSelection() },
-                onClickReleaseSelection = { onClickReleaseSelection() }
-            )
+            CART_CHECK_HEADER -> {
+                checkHeaderViewHolder = CheckHeaderViewHolder(
+                    ItemCartCheckHeaderBinding.inflate(
+                        LayoutInflater.from(
+                            parent.context
+                        ), parent, false
+                    ),
+                    onClickRemoveSelection = { onClickRemoveSelection() },
+                    onClickAllSelection = { onClickAllSelection() },
+                    onClickReleaseSelection = { onClickReleaseSelection() }
+                )
+                checkHeaderViewHolder!!
+            }
             CART_CONTENT -> CartContentViewHolder(
                 ItemCartBinding.inflate(
                     LayoutInflater.from(
@@ -82,7 +88,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
-            CART_CHECK_HEADER -> (holder as CheckHeaderViewHolder).bind()
+            CART_CHECK_HEADER -> (holder as CheckHeaderViewHolder).bind(checkStateFlag)
             CART_CONTENT -> (holder as CartContentViewHolder).bind(getItem(position))
             CART_TOTAL_PRICE -> (holder as TotalPriceViewHolder).bind(totalPrice)
             CART_FOOTER_BTN -> (holder as CartFooterBtnViewHolder).bind(totalPrice)
@@ -114,11 +120,15 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
         newList.add(null)
         if (list.isEmpty()) newList.add(emptyCart())
-        else list.forEach { newList.add(it) }
+        else list.forEachIndexed { index, cart ->
+            checkStateFlag = checkStateFlag.or(cart.checkState.toInt().shl(index))
+            newList.add(cart)
+        }
         repeat(3) { newList.add(null) }
 
         submitList(newList)
         updateTotalPrice()
+        checkHeaderViewHolder?.bind(checkStateFlag)
     }
 
     private fun updateTotalPrice() {
@@ -140,6 +150,16 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
         tmpList.forEach { if (it.checkState) onClickCartRemove(it) }
     }
 
+    private fun onClickAllSelection() {
+        cartList.forEach {
+            if (it.checkState.not()) {
+                it.checkState = true
+                onClickCartCheckState(it)
+            }
+        }
+        notifyDataSetChanged()
+    }
+
     private fun onClickReleaseSelection() {
         cartList.forEach {
             if (it.checkState) {
@@ -151,6 +171,8 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
     }
 
     private fun onClickCartCheckState(cart: Cart) {
+        checkStateFlag = checkStateFlag.xor((1).shl(cartList.indexOf(cart)))
+        checkHeaderViewHolder?.bind(checkStateFlag)
         updateTotalPrice()
         listener?.onClickCartUpdate(cart)
     }
@@ -183,6 +205,8 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
                 oldItem.hash == newItem.hash
         }
     }
+
+    private fun Boolean.toInt() = if (this) 1 else 0
 
     interface CartButtonCallBackListener {
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -23,6 +23,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
     private var cartFooterBtnViewHolder: CartFooterBtnViewHolder? = null
 
     private var totalPrice = 0
+    private var checkOriginStateFlag = 0
     private var checkStateFlag = 0
     private var listener: CartButtonCallBackListener? = null
 
@@ -88,7 +89,10 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
-            CART_CHECK_HEADER -> (holder as CheckHeaderViewHolder).bind(checkStateFlag)
+            CART_CHECK_HEADER -> (holder as CheckHeaderViewHolder).bind(
+                checkOriginStateFlag,
+                checkStateFlag
+            )
             CART_CONTENT -> (holder as CartContentViewHolder).bind(getItem(position))
             CART_TOTAL_PRICE -> (holder as TotalPriceViewHolder).bind(totalPrice)
             CART_FOOTER_BTN -> (holder as CartFooterBtnViewHolder).bind(totalPrice)
@@ -116,6 +120,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
     fun submitCartList(list: List<Cart>) {
         // 첫번째, 마지막, 마지막-1,마지막-2
         cartList = list.toMutableList()
+        checkOriginStateFlag = (1).shl(list.size) - 1
         val newList = mutableListOf<Cart?>()
 
         newList.add(null)
@@ -128,7 +133,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
         submitList(newList)
         updateTotalPrice()
-        checkHeaderViewHolder?.bind(checkStateFlag)
+        checkHeaderViewHolder?.bind(checkOriginStateFlag, checkStateFlag)
     }
 
     private fun updateTotalPrice() {
@@ -172,7 +177,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
 
     private fun onClickCartCheckState(cart: Cart) {
         checkStateFlag = checkStateFlag.xor((1).shl(cartList.indexOf(cart)))
-        checkHeaderViewHolder?.bind(checkStateFlag)
+        checkHeaderViewHolder?.bind(checkOriginStateFlag, checkStateFlag)
         updateTotalPrice()
         listener?.onClickCartUpdate(cart)
     }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
@@ -56,6 +56,7 @@ class CartContentViewHolder(
             if (c < minimumCount) minimumCount else if (c > maximumCount) maximumCount else c
 
         binding.itemCount = cart.count.toString()
+        binding.cart = cart
         onClickCartUpdateCount(cart, msg)
     }
 
@@ -67,6 +68,7 @@ class CartContentViewHolder(
             if (count < minimumCount || count > maximumCount) overflowMessage else null
         cart.count =
             if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
+        binding.cart = cart
         onClickCartUpdateCount(cart, msg)
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
@@ -11,8 +11,8 @@ class CheckHeaderViewHolder(
 ) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(checkStateFlag: Int) {
-        binding.checkStateFlag = checkStateFlag != 0
+    fun bind(checkOriginStateFlag: Int, checkStateFlag: Int) {
+        binding.checkStateFlag = checkStateFlag == checkOriginStateFlag
         binding.tvRemoveSelection.setOnClickListener { onClickRemoveSelection() }
         binding.tvAllChecked.setOnClickListener { onClickAllSelection() }
         binding.tvReleaseChecked.setOnClickListener { onClickReleaseSelection() }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
@@ -5,14 +5,16 @@ import com.woowa.banchan.databinding.ItemCartCheckHeaderBinding
 
 class CheckHeaderViewHolder(
     private val binding: ItemCartCheckHeaderBinding,
-    private val onClickRemoveSelection: () -> Unit = {},
-    private val onClickReleaseSelection: () -> Unit = {}
+    private val onClickRemoveSelection: () -> Unit,
+    private val onClickAllSelection: () -> Unit,
+    private val onClickReleaseSelection: () -> Unit
 ) :
     RecyclerView.ViewHolder(binding.root) {
 
-
-    fun bind() {
+    fun bind(checkStateFlag: Int) {
+        binding.checkStateFlag = checkStateFlag != 0
         binding.tvRemoveSelection.setOnClickListener { onClickRemoveSelection() }
+        binding.tvAllChecked.setOnClickListener { onClickAllSelection() }
         binding.tvReleaseChecked.setOnClickListener { onClickReleaseSelection() }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/popup/CartCompleteFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/popup/CartCompleteFragment.kt
@@ -23,7 +23,8 @@ class CartCompleteFragment : DialogFragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_cart_complete, container, false)
+        binding =
+            DataBindingUtil.inflate(inflater, R.layout.fragment_cart_complete, container, false)
         initDialog()
         return binding.root
     }
@@ -41,6 +42,7 @@ class CartCompleteFragment : DialogFragment() {
     private fun initButtonSetting() {
         binding.tvCartConfirm.setOnClickListener {
             parentFragmentManager.commit { remove(this@CartCompleteFragment) }
+            if (this.requireActivity() is CartActivity) this.requireActivity().finish()
             startActivity(Intent(context, CartActivity::class.java))
         }
         binding.tvContinueShopping.setOnClickListener {

--- a/app/src/main/res/layout/item_cart_check_header.xml
+++ b/app/src/main/res/layout/item_cart_check_header.xml
@@ -5,6 +5,11 @@
 
     <data>
 
+        <variable
+            name="checkStateFlag"
+            type="Boolean" />
+
+        <import type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -20,6 +25,7 @@
             android:focusable="true"
             android:gravity="center"
             android:orientation="horizontal"
+            android:visibility="@{checkStateFlag ? View.VISIBLE : View.GONE}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
@@ -33,6 +39,30 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="선택 해제" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/tv_all_checked"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="@{checkStateFlag ? View.GONE : View.VISIBLE}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_unchecked" />
+
+            <TextView
+                style="@style/normal_14"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="전체 선택" />
         </LinearLayout>
 
         <TextView


### PR DESCRIPTION
### ❗️ 이슈
- close #80 

### 📝 구현한 내용
- 카트 아이템 수량 변경에 따라 우측 하단 가격 변경
- 카트 화면에서 장바구니 버튼을 추가할 시 중복 activity를 생성하는 것을 해결
- 전체 선택 기능 구현
  - 전체 리스트에 대한 flag로 현재 선택된 아이템들에 대한 내용을 기록한다.
  - index -> 1 일경우 1번째자리에 bit를 토글해서 기록
  - 이를 viewholder에서 확인 후 변경한다.

### ❓ 고민한 내용
- 전체 선택을 위해 모든 아이템의 checkState를 확인할 것인가
  - 아이템 전체가 체크가 되어 있지 않을 때 전체 선택을 보여줘야 한다.
  - 이를 아이템이 변경될 때마다 확인하는 것은 매우 비효율 적이다.
  - 따라서, 하나의 비트연산할 변수를 두고 각 아이템의 비트연산을 통해 모두 checkState가 0인지를 확인한다.
  - 받아올 때 리스트의 인덱스와 checkState를 통해 1 or 0을 flag 세우고 bind를 호출해 이를 갱신한다.
