### PR TITLE
fix: GridLayout 간격 수정

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/RecentPreviewRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/RecentPreviewRVAdapter.kt
@@ -26,8 +26,6 @@ class RecentPreviewRVAdapter(
         holder.bind(
             getItem(position),
             onClickItem = { onClickItem(it) },
-            onClickCartButton = {},
-            onClickCheckButton = {}
         )
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentItemViewHolder.kt
@@ -10,15 +10,11 @@ class RecentItemViewHolder(private val binding: ItemRecentBinding) :
     fun bind(
         recent: Recent,
         isPreview: Boolean = true,
-        onClickItem: (recent: Recent) -> Unit,
-        onClickCartButton: (recent: Recent) -> Unit = {},
-        onClickCheckButton: (recent: Recent) -> Unit = {}
+        onClickItem: (recent: Recent) -> Unit
     ) {
         binding.isPreview = isPreview
         binding.recent = recent
 
-        binding.ivCart.setOnClickListener { onClickCartButton(recent) }
-        binding.ivCheck.setOnClickListener { onClickCheckButton(recent) }
         binding.root.setOnClickListener { onClickItem(recent) }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentGridItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentGridItemViewHolder.kt
@@ -10,11 +10,15 @@ class RecentGridItemViewHolder(private val binding: ItemRecentGridBinding) :
     fun bind(
         recent: Recent,
         isPreview: Boolean = true,
-        onClickCartButton: (recent: Recent) -> Unit = {}
+        onClickItem: (recent: Recent) -> Unit,
+        onClickCartButton: (recent: Recent) -> Unit = {},
+        onClickCheckButton: (recent: Recent) -> Unit = {}
     ) {
         binding.isPreview = isPreview
         binding.recent = recent
 
         binding.ivCart.setOnClickListener { onClickCartButton(recent) }
+        binding.ivCheck.setOnClickListener { onClickCheckButton(recent) }
+        binding.root.setOnClickListener { onClickItem(recent) }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentGridItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentGridItemViewHolder.kt
@@ -1,0 +1,20 @@
+package com.woowa.banchan.ui.cart.recent.adapter
+
+import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemRecentGridBinding
+import com.woowa.banchan.domain.model.Recent
+
+class RecentGridItemViewHolder(private val binding: ItemRecentGridBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(
+        recent: Recent,
+        isPreview: Boolean = true,
+        onClickCartButton: (recent: Recent) -> Unit = {}
+    ) {
+        binding.isPreview = isPreview
+        binding.recent = recent
+
+        binding.ivCart.setOnClickListener { onClickCartButton(recent) }
+    }
+}

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
@@ -4,18 +4,18 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import com.woowa.banchan.databinding.ItemRecentGridBinding
 import com.woowa.banchan.databinding.ItemRecentBinding
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Recent
-import com.woowa.banchan.ui.cart.cart.adapter.viewholder.RecentItemViewHolder
 
-class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
+class RecentRVAdapter : ListAdapter<Recent, RecentGridItemViewHolder>(diffUtil) {
 
     private var listener: RecentlyViewedCallBackListener? = null
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentItemViewHolder {
-        return RecentItemViewHolder(
-            ItemRecentBinding.inflate(
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentGridItemViewHolder {
+        return RecentGridItemViewHolder(
+            ItemRecentGridBinding.inflate(
                 LayoutInflater.from(parent.context),
                 parent,
                 false
@@ -23,6 +23,8 @@ class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
         )
     }
 
+    override fun onBindViewHolder(holder: RecentGridItemViewHolder, position: Int) {
+        holder.bind(getItem(position), isPreview = false) { this.onClickCartButton(it) }
     override fun onBindViewHolder(holder: RecentItemViewHolder, position: Int) {
         holder.bind(
             getItem(position),

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.woowa.banchan.databinding.ItemRecentGridBinding
-import com.woowa.banchan.databinding.ItemRecentBinding
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Recent
 
@@ -24,8 +23,6 @@ class RecentRVAdapter : ListAdapter<Recent, RecentGridItemViewHolder>(diffUtil) 
     }
 
     override fun onBindViewHolder(holder: RecentGridItemViewHolder, position: Int) {
-        holder.bind(getItem(position), isPreview = false) { this.onClickCartButton(it) }
-    override fun onBindViewHolder(holder: RecentItemViewHolder, position: Int) {
         holder.bind(
             getItem(position),
             isPreview = false,

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
@@ -2,6 +2,7 @@ package com.woowa.banchan.ui.home.adapter.viewholder
 
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemBestBinding
 import com.woowa.banchan.databinding.ItemHomeBinding
 import com.woowa.banchan.databinding.ItemMainLinearBinding
 import com.woowa.banchan.domain.model.FoodItem

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
@@ -2,7 +2,6 @@ package com.woowa.banchan.ui.home.adapter.viewholder
 
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
-import com.woowa.banchan.databinding.ItemBestBinding
 import com.woowa.banchan.databinding.ItemHomeBinding
 import com.woowa.banchan.databinding.ItemMainLinearBinding
 import com.woowa.banchan.domain.model.FoodItem

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeRecyclerViewViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeRecyclerViewViewHolder.kt
@@ -26,6 +26,9 @@ class HomeRecyclerViewViewHolder(private val binding: ItemRecyclerviewBinding) :
     private fun initLayoutManager(homeRVAdapter: HomeRVAdapter) {
         binding.rvBest.apply {
             layoutManager = when (homeRVAdapter.managerType) {
+    fun bind(homeRVAdapter: HomeRVAdapter, food: List<FoodItem>, managerType: Int) {
+        binding.rvFood.apply {
+            layoutManager = when (managerType) {
                 LINEAR_HORIZONTAL -> LinearLayoutManager(
                     this.context,
                     LinearLayoutManager.HORIZONTAL,

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeRecyclerViewViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeRecyclerViewViewHolder.kt
@@ -14,21 +14,18 @@ class HomeRecyclerViewViewHolder(private val binding: ItemRecyclerviewBinding) :
 
     fun bind(homeRVAdapter: HomeRVAdapter) {
         initLayoutManager(homeRVAdapter)
-        binding.rvBest.adapter = homeRVAdapter
+        binding.rvFood.adapter = homeRVAdapter
     }
 
     fun bind(homeRVAdapter: HomeRVAdapter, items: List<FoodItem>) {
         initLayoutManager(homeRVAdapter)
-        binding.rvBest.adapter = homeRVAdapter
+        binding.rvFood.adapter = homeRVAdapter
         homeRVAdapter.submitList(items)
     }
 
     private fun initLayoutManager(homeRVAdapter: HomeRVAdapter) {
-        binding.rvBest.apply {
-            layoutManager = when (homeRVAdapter.managerType) {
-    fun bind(homeRVAdapter: HomeRVAdapter, food: List<FoodItem>, managerType: Int) {
         binding.rvFood.apply {
-            layoutManager = when (managerType) {
+            layoutManager = when (homeRVAdapter.managerType) {
                 LINEAR_HORIZONTAL -> LinearLayoutManager(
                     this.context,
                     LinearLayoutManager.HORIZONTAL,

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestItemAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestItemAdapter.kt
@@ -1,0 +1,45 @@
+package com.woowa.banchan.ui.home.best.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.woowa.banchan.databinding.ItemBestBinding
+import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.ui.home.best.adapter.viewholder.BestItemViewHolder
+
+class BestItemAdapter(
+    private val itemClickListener: (String, String) -> Unit,
+    private val cartClickListener: (FoodItem) -> Unit
+) :
+    ListAdapter<FoodItem, BestItemViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BestItemViewHolder {
+        return BestItemViewHolder(
+            ItemBestBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: BestItemViewHolder, position: Int) {
+        holder.bind(getItem(position), itemClickListener, cartClickListener)
+    }
+
+    companion object {
+
+        val diffUtil = object : DiffUtil.ItemCallback<FoodItem>() {
+            override fun areItemsTheSame(oldItem: FoodItem, newItem: FoodItem): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: FoodItem, newItem: FoodItem): Boolean {
+                return oldItem.detailHash == newItem.detailHash
+            }
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -8,13 +8,14 @@ import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemBestHeaderBinding
 import com.woowa.banchan.databinding.ItemBestRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
-import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.domain.model.BestFoodCategory
 import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.ui.home.HOME_HEADER
+import com.woowa.banchan.ui.home.HOME_ITEM
+import com.woowa.banchan.ui.home.SUB_HEADER
 import com.woowa.banchan.ui.home.*
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
-import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestHeaderViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestViewHolder
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemBestHeaderBinding
+import com.woowa.banchan.databinding.ItemBestRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.domain.model.BestFoodCategory
@@ -15,6 +16,7 @@ import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestHeaderViewHolder
+import com.woowa.banchan.ui.home.best.adapter.viewholder.BestViewHolder
 
 class BestRVAdapter(
     private val itemClickListener: (String, String) -> Unit,
@@ -37,8 +39,8 @@ class BestRVAdapter(
                     ), parent, false
                 )
             )
-            else -> HomeRecyclerViewViewHolder(
-                ItemRecyclerviewBinding.inflate(
+            else -> BestViewHolder(
+                ItemBestRecyclerviewBinding.inflate(
                     LayoutInflater.from(
                         parent.context
                     ), parent, false
@@ -54,6 +56,12 @@ class BestRVAdapter(
             is HomeRecyclerViewViewHolder -> holder.bind(
                 HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
                 (getItem(position) as RVItem.Item<BestFoodCategory>).item.items,
+        when (holder.itemViewType) {
+            HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("한 번 주문하면\n두 번 반하는 반찬들", true)
+            SUB_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position))
+            else -> (holder as BestViewHolder).bind(
+                BestItemAdapter(itemClickListener, cartClickListener),
+                getItem(position).items
             )
         }
     }
@@ -88,6 +96,13 @@ class BestRVAdapter(
 
             override fun areContentsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
                 return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(
+                oldItem: BestFoodCategory,
+                newItem: BestFoodCategory
+            ): Boolean {
+                return oldItem.categoryId == newItem.categoryId
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -12,9 +12,8 @@ import com.woowa.banchan.domain.model.BestFoodCategory
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.home.HOME_HEADER
 import com.woowa.banchan.ui.home.HOME_ITEM
+import com.woowa.banchan.ui.home.RVItem
 import com.woowa.banchan.ui.home.SUB_HEADER
-import com.woowa.banchan.ui.home.*
-import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestHeaderViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestViewHolder
@@ -54,15 +53,9 @@ class BestRVAdapter(
         when (holder) {
             is HomeHeaderViewHolder -> holder.bind("한 번 주문하면\n두 번 반하는 반찬들", true)
             is BestHeaderViewHolder -> holder.bind((getItem(position) as RVItem.Item<BestFoodCategory>).item)
-            is HomeRecyclerViewViewHolder -> holder.bind(
-                HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
-                (getItem(position) as RVItem.Item<BestFoodCategory>).item.items,
-        when (holder.itemViewType) {
-            HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("한 번 주문하면\n두 번 반하는 반찬들", true)
-            SUB_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position))
-            else -> (holder as BestViewHolder).bind(
+            is BestViewHolder -> holder.bind(
                 BestItemAdapter(itemClickListener, cartClickListener),
-                getItem(position).items
+                (getItem(position) as RVItem.Item<BestFoodCategory>).item.items
             )
         }
     }
@@ -97,13 +90,6 @@ class BestRVAdapter(
 
             override fun areContentsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
                 return oldItem == newItem
-            }
-
-            override fun areContentsTheSame(
-                oldItem: BestFoodCategory,
-                newItem: BestFoodCategory
-            ): Boolean {
-                return oldItem.categoryId == newItem.categoryId
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestItemViewHolder.kt
@@ -1,0 +1,22 @@
+package com.woowa.banchan.ui.home.best.adapter.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemBestBinding
+import com.woowa.banchan.domain.model.FoodItem
+
+class BestItemViewHolder(private val binding: ItemBestBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(food: FoodItem, itemClickListener: (String, String) -> Unit, cartClickListener: (FoodItem) -> Unit) {
+        binding.food = food
+        binding.layoutHome.setOnClickListener {
+            itemClickListener(food.title, food.detailHash)
+        }
+        binding.ivCart.setOnClickListener {
+            cartClickListener(food)
+        }
+        binding.ivCheck.setOnClickListener {
+            cartClickListener(food)
+        }
+    }
+}

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestViewHolder.kt
@@ -1,0 +1,16 @@
+package com.woowa.banchan.ui.home.best.adapter.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemBestRecyclerviewBinding
+import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.ui.home.best.adapter.BestItemAdapter
+
+class BestViewHolder(private val binding: ItemBestRecyclerviewBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(bestItemAdapter: BestItemAdapter, food: List<FoodItem>) {
+        binding.rvBest.adapter = bestItemAdapter
+        bestItemAdapter.submitList(food)
+
+    }
+}

--- a/app/src/main/res/layout/fragment_recent.xml
+++ b/app/src/main/res/layout/fragment_recent.xml
@@ -11,7 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:paddingStart="8dp"
+        android:paddingHorizontal="8dp"
         android:text="@string/fragment_recent"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
         app:spanCount="2"

--- a/app/src/main/res/layout/item_best.xml
+++ b/app/src/main/res/layout/item_best.xml
@@ -9,20 +9,16 @@
             name="food"
             type="com.woowa.banchan.domain.model.FoodItem" />
 
-        <variable
-            name="checkState"
-            type="Boolean" />
-
         <import type="android.view.View" />
 
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_main"
-        android:layout_width="match_parent"
+        android:id="@+id/layout_home"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingVertical="16dp"
-        android:paddingHorizontal="16dp">
+        android:paddingEnd="8dp">
 
         <ImageView
             android:id="@+id/iv_thumbnail"
@@ -41,7 +37,7 @@
             android:elevation="8dp"
             android:padding="8dp"
             android:src="@drawable/ic_cart"
-            android:visibility="@{checkState ? View.GONE : View.VISIBLE}"
+            android:visibility="@{food.checkState ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
 
@@ -54,7 +50,7 @@
             android:elevation="8dp"
             android:padding="8dp"
             android:src="@drawable/ic_check_white"
-            android:visibility="@{checkState ? View.VISIBLE : View.GONE}"
+            android:visibility="@{food.checkState ? View.VISIBLE : View.GONE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
 
@@ -63,14 +59,13 @@
             style="@style/normal_14"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
             android:ellipsize="end"
             android:maxLines="1"
+            android:paddingTop="8dp"
             android:text="@{food.title}"
-            app:layout_constraintBottom_toTopOf="@id/tv_content"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/iv_thumbnail"
-            app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_thumbnail"
             tools:text="오리 주물럭_반조리" />
 
         <TextView
@@ -78,10 +73,10 @@
             style="@style/caption_grey"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:paddingVertical="8dp"
             android:text="@{food.description}"
-            app:layout_constraintBottom_toTopOf="@id/tv_s_price"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             tools:text="감칠맛 나는 매콤 양념" />
 
@@ -91,8 +86,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingEnd="4dp"
-            app:layout_constraintBottom_toTopOf="@id/tv_n_price"
-            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_content"
             app:percent="@{food.percent}"
             tools:text="20%" />
@@ -102,7 +96,6 @@
             style="@style/normal_14"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@id/tv_n_price"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_percent"
             app:layout_constraintTop_toBottomOf="@id/tv_content"
@@ -115,14 +108,13 @@
             style="@style/caption_grey"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
+            android:paddingTop="8dp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/tv_title"
-            app:layout_constraintTop_toBottomOf="@id/tv_s_price"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_percent"
             app:nPrice="@{food.nPrice}"
             app:sPrice="@{null}"
             tools:text="15,800원" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_best_recyclerview.xml
+++ b/app/src/main/res/layout/item_best_recyclerview.xml
@@ -8,9 +8,11 @@
     </data>
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_food"
+        android:id="@+id/rv_best"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:orientation="horizontal"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:context=".ui.home.best.BestFragment"
         tools:listitem="@layout/item_best" />

--- a/app/src/main/res/layout/item_home.xml
+++ b/app/src/main/res/layout/item_home.xml
@@ -19,15 +19,15 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_home"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="16dp"
-        android:paddingEnd="8dp">
+        android:padding="16dp">
 
         <ImageView
             android:id="@+id/iv_thumbnail"
-            android:layout_width="168dp"
-            android:layout_height="168dp"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="1:1"
             app:image="@{food.image}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_home.xml
+++ b/app/src/main/res/layout/item_home.xml
@@ -21,7 +21,7 @@
         android:id="@+id/layout_home"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:padding="8dp">
 
         <ImageView
             android:id="@+id/iv_thumbnail"

--- a/app/src/main/res/layout/item_main_linear.xml
+++ b/app/src/main/res/layout/item_main_linear.xml
@@ -22,7 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingVertical="16dp"
-        android:paddingHorizontal="16dp">
+        android:paddingHorizontal="8dp">
 
         <ImageView
             android:id="@+id/iv_thumbnail"

--- a/app/src/main/res/layout/item_recent.xml
+++ b/app/src/main/res/layout/item_recent.xml
@@ -31,34 +31,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/iv_cart"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="8dp"
-            android:background="@drawable/background_circle_white"
-            android:clickable="true"
-            android:elevation="8dp"
-            android:focusable="true"
-            android:padding="8dp"
-            android:src="@drawable/ic_cart"
-            android:visibility="@{(isPreview||recent.checkState) ? View.GONE : View.VISIBLE}"
-            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
-            app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
-
-        <ImageView
-            android:id="@+id/iv_check"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="8dp"
-            android:background="@drawable/background_circle_accent"
-            android:elevation="8dp"
-            android:padding="8dp"
-            android:src="@drawable/ic_check_white"
-            android:visibility="@{(!isPreview &amp;&amp; recent.checkState) ? View.VISIBLE : View.GONE}"
-            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
-            app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
-
         <TextView
             android:id="@+id/tv_title"
             style="@style/bold_14"

--- a/app/src/main/res/layout/item_recent.xml
+++ b/app/src/main/res/layout/item_recent.xml
@@ -19,14 +19,14 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingVertical="16dp"
-        android:paddingEnd="8dp">
+        android:padding="16dp">
 
         <ImageView
             android:id="@+id/iv_thumbnail"
             android:layout_width="168dp"
             android:layout_height="168dp"
             android:background="@color/main"
+            app:layout_constraintDimensionRatio="1:1"
             app:image="@{recent.imageUrl}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_recent_grid.xml
+++ b/app/src/main/res/layout/item_recent_grid.xml
@@ -19,7 +19,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:padding="8dp">
 
         <ImageView
             android:id="@+id/iv_thumbnail"

--- a/app/src/main/res/layout/item_recent_grid.xml
+++ b/app/src/main/res/layout/item_recent_grid.xml
@@ -17,16 +17,16 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="16dp"
-        android:paddingEnd="8dp">
+        android:padding="16dp">
 
         <ImageView
             android:id="@+id/iv_thumbnail"
-            android:layout_width="168dp"
-            android:layout_height="168dp"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
             android:background="@color/main"
+            app:layout_constraintDimensionRatio="1:1"
             app:image="@{recent.imageUrl}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -42,23 +42,10 @@
             android:focusable="true"
             android:padding="8dp"
             android:src="@drawable/ic_cart"
-            android:visibility="@{(isPreview||recent.checkState) ? View.GONE : View.VISIBLE}"
+            android:visibility="@{isPreview ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
-
-        <ImageView
-            android:id="@+id/iv_check"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="8dp"
-            android:background="@drawable/background_circle_accent"
-            android:elevation="8dp"
-            android:padding="8dp"
-            android:src="@drawable/ic_check_white"
-            android:visibility="@{(!isPreview &amp;&amp; recent.checkState) ? View.VISIBLE : View.GONE}"
-            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
-            app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
-
+        F
         <TextView
             android:id="@+id/tv_title"
             style="@style/bold_14"

--- a/app/src/main/res/layout/item_recent_grid.xml
+++ b/app/src/main/res/layout/item_recent_grid.xml
@@ -45,7 +45,20 @@
             android:visibility="@{isPreview ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
-        F
+
+        <ImageView
+            android:id="@+id/iv_check"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_margin="8dp"
+            android:background="@drawable/background_circle_accent"
+            android:elevation="8dp"
+            android:padding="8dp"
+            android:src="@drawable/ic_check_white"
+            android:visibility="@{(!isPreview &amp;&amp; recent.checkState) ? View.VISIBLE : View.GONE}"
+            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
+            app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
+
         <TextView
             android:id="@+id/tv_title"
             style="@style/bold_14"

--- a/app/src/main/res/layout/item_recyclerview.xml
+++ b/app/src/main/res/layout/item_recyclerview.xml
@@ -11,6 +11,7 @@
         android:id="@+id/rv_food"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingHorizontal="8dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:context=".ui.home.best.BestFragment"
         tools:listitem="@layout/item_best" />


### PR DESCRIPTION
### ❗️ 이슈
- close #49 

### 📝 구현한 내용
- GridLayout에 쓰이는 Item의 간격을 match_parent로 설정.

### ❓ 고민한 내용
item의 넓이를 match_parent로 한 후 spanCount만 설정해주면 GridLayout의 간격은 잘 정리가 됩니다.
하지만 match_parent인 아이템은 GridLayout에서 밖에 활용할 수 없어서
결국 유사한 item을 하나 더 만들 수 밖에 없습니다.
이 과정에서 보일러플레이트 코드가 많이 생성될 것 같아서 고민하였지만,
재활용하기 위해 억지로 코드에 로직을 추가하는 것이 오히려 더 복잡해질 것 같아서
유사한 item을 만드는 방법을 선택하였습니다.
