### PR TITLE
feat: Recent 기능(클릭 시 디테일 이동 및 장바구니 아이콘) 구현 및 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
             android:exported="false" />
         <activity
             android:name=".ui.detail.DetailActivity"
-            android:exported="true" />
+            android:exported="true"
+            android:launchMode="singleTop" />
         <activity
             android:name=".ui.home.HomeActivity"
             android:exported="true"

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSource.kt
@@ -5,5 +5,6 @@ import com.woowa.banchan.data.local.entity.RecentDto
 interface RecentDataSource {
 
     suspend fun getRecentList(): Result<List<RecentDto>>
+    suspend fun deleteRecent(recentDto: RecentDto): Result<Unit>
     suspend fun insertRecent(recentDto: RecentDto): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.woowa.banchan.data.local.datasource.recent
 
 import com.woowa.banchan.data.local.dao.RecentDao
 import com.woowa.banchan.data.local.entity.RecentDto
+import java.util.*
 import javax.inject.Inject
 
 class RecentDataSourceImpl @Inject constructor(
@@ -9,7 +10,20 @@ class RecentDataSourceImpl @Inject constructor(
 ) : RecentDataSource {
 
     override suspend fun getRecentList(): Result<List<RecentDto>> =
-        runCatching { recentDao.getRecentList() }
+        runCatching {
+            val list = recentDao.getRecentList().toMutableList()
+            val curCalendar = Calendar.getInstance()
+                .apply { time = Date() }
+            val calendar = Calendar.getInstance()
+            val retList = mutableListOf<RecentDto>()
+            list.forEach {
+                calendar.time = it.time
+                if (calendar.get(Calendar.DAY_OF_WEEK) != curCalendar.get(Calendar.DAY_OF_WEEK))
+                    recentDao.delete(it)
+                else retList.add(it)
+            }
+            retList
+        }
 
     override suspend fun insertRecent(recentDto: RecentDto): Result<Unit> =
         runCatching { recentDao.insert(recentDto) }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/recent/RecentDataSourceImpl.kt
@@ -2,7 +2,6 @@ package com.woowa.banchan.data.local.datasource.recent
 
 import com.woowa.banchan.data.local.dao.RecentDao
 import com.woowa.banchan.data.local.entity.RecentDto
-import java.util.*
 import javax.inject.Inject
 
 class RecentDataSourceImpl @Inject constructor(
@@ -10,20 +9,10 @@ class RecentDataSourceImpl @Inject constructor(
 ) : RecentDataSource {
 
     override suspend fun getRecentList(): Result<List<RecentDto>> =
-        runCatching {
-            val list = recentDao.getRecentList().toMutableList()
-            val curCalendar = Calendar.getInstance()
-                .apply { time = Date() }
-            val calendar = Calendar.getInstance()
-            val retList = mutableListOf<RecentDto>()
-            list.forEach {
-                calendar.time = it.time
-                if (calendar.get(Calendar.DAY_OF_WEEK) != curCalendar.get(Calendar.DAY_OF_WEEK))
-                    recentDao.delete(it)
-                else retList.add(it)
-            }
-            retList
-        }
+        runCatching { recentDao.getRecentList() }
+
+    override suspend fun deleteRecent(recentDto: RecentDto): Result<Unit> =
+        runCatching { recentDao.delete(recentDto) }
 
     override suspend fun insertRecent(recentDto: RecentDto): Result<Unit> =
         runCatching { recentDao.insert(recentDto) }

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/RecentDto.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/RecentDto.kt
@@ -33,8 +33,7 @@ fun Recent.toFoodItem(): FoodItem = FoodItem(
     image = imageUrl,
     nPrice = nPrice,
     sPrice = sPrice,
-    percent = if (nPrice == null) null else (((sPrice - nPrice) * 100) / sPrice),
-    //((sPrice - nPrice) * 100) / sPrice,
+    percent = if (nPrice == null) null else (((nPrice - sPrice) * 100) / nPrice),
     title = title
 )
 

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/RecentRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/RecentRepositoryImpl.kt
@@ -1,20 +1,33 @@
 package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.recent.RecentDataSource
+import com.woowa.banchan.data.local.entity.RecentDto
 import com.woowa.banchan.data.local.entity.toRecent
 import com.woowa.banchan.data.local.entity.toRecentDto
 import com.woowa.banchan.domain.model.Recent
 import com.woowa.banchan.domain.repository.RecentRepository
+import java.util.*
 import javax.inject.Inject
 
 class RecentRepositoryImpl @Inject constructor(
     private val recentDataSource: RecentDataSource
 ) : RecentRepository {
 
-    override suspend fun getRecentList(): Result<List<Recent>> {
-        val list = recentDataSource.getRecentList().getOrThrow()
-        return runCatching { list.map { it.toRecent() } }
-    }
+    override suspend fun getRecentList(): Result<List<Recent>> =
+        runCatching {
+            val list = recentDataSource.getRecentList().getOrThrow()
+            val curCalendar = Calendar.getInstance()
+                .apply { time = Date() }
+            val calendar = Calendar.getInstance()
+            val retList = mutableListOf<RecentDto>()
+            list.forEach {
+                calendar.time = it.time
+                if (calendar.get(Calendar.DAY_OF_WEEK) != curCalendar.get(Calendar.DAY_OF_WEEK))
+                    recentDataSource.deleteRecent(it)
+                else retList.add(it)
+            }
+            retList.map { it.toRecent() }
+        }
 
     override suspend fun insertRecent(recent: Recent): Result<Unit> =
         runCatching { recentDataSource.insertRecent(recent.toRecentDto()) }

--- a/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Recent.kt
@@ -9,4 +9,5 @@ data class Recent(
     val sPrice: Int,
     val title: String,
     val imageUrl: String,
+    var checkState: Boolean = false
 )

--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -67,6 +68,10 @@ class CartViewModel @Inject constructor(
                 launch { updateCartUseCase(it.first).collect {} }
             }
         }
+    }
+
+    fun deleteCart(recent: Recent) {
+        CoroutineScope(Dispatchers.IO).launch { deleteCartUseCase(recent.hash).collect() }
     }
 
     fun addUpdateCartCache(cart: Cart, removeFlag: Boolean) {

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -13,9 +13,11 @@ import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentCartBinding
 import com.woowa.banchan.domain.model.Cart
+import com.woowa.banchan.domain.model.Recent
 import com.woowa.banchan.ui.cart.CartViewModel
 import com.woowa.banchan.ui.cart.cart.adapter.CartRVAdapter
 import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.ui.detail.DetailActivity
 import com.woowa.banchan.ui.order.detail.OrderDetailActivity
 import com.woowa.banchan.utils.showToast
 import kotlinx.coroutines.flow.launchIn
@@ -64,6 +66,17 @@ class CartFragment : Fragment() {
 
             override fun onClickOrderButton() {
                 viewModel.addOrder()
+            }
+
+            override fun onClickRecentItem(recent: Recent) {
+                val intent =
+                    Intent(this@CartFragment.requireActivity(), DetailActivity::class.java)
+                with(intent) {
+                    putExtra("title", recent.title)
+                    putExtra("hash", recent.hash)
+                }
+                startActivity(intent)
+                this@CartFragment.requireActivity().finish()
             }
 
             override fun onClickAllRecentlyViewed() {

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -72,8 +72,9 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
                         LayoutInflater.from(
                             parent.context
                         ), parent, false
-                    ), onClickAllRecentlyViewed
-                    = { onClickAllRecentlyViewed() }
+                    ),
+                    onClickRecentItem = { onClickRecentItem(it) },
+                    onClickAllRecentlyViewed = { onClickAllRecentlyViewed() },
                 )
                 recentPreviewViewHolder!!
             }
@@ -170,6 +171,10 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
         listener?.onClickOrderButton()
     }
 
+    private fun onClickRecentItem(recent: Recent) {
+        listener?.onClickRecentItem(recent)
+    }
+
     private fun onClickAllRecentlyViewed() {
         listener?.onClickAllRecentlyViewed()
     }
@@ -189,6 +194,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
         fun onClickCartUpdate(cart: Cart, message: String? = null)
         fun onClickCartRemove(cart: Cart)
         fun onClickOrderButton()
+        fun onClickRecentItem(recent: Recent)
         fun onClickAllRecentlyViewed()
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/RecentPreviewRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/RecentPreviewRVAdapter.kt
@@ -8,7 +8,9 @@ import com.woowa.banchan.databinding.ItemRecentBinding
 import com.woowa.banchan.domain.model.Recent
 import com.woowa.banchan.ui.cart.cart.adapter.viewholder.RecentItemViewHolder
 
-class RecentPreviewRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
+class RecentPreviewRVAdapter(
+    private val onClickItem: (recent: Recent) -> Unit,
+) : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentItemViewHolder {
         return RecentItemViewHolder(
@@ -21,7 +23,7 @@ class RecentPreviewRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUti
     }
 
     override fun onBindViewHolder(holder: RecentItemViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), onClickItem = { onClickItem(it) })
     }
 
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/RecentPreviewRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/RecentPreviewRVAdapter.kt
@@ -23,7 +23,12 @@ class RecentPreviewRVAdapter(
     }
 
     override fun onBindViewHolder(holder: RecentItemViewHolder, position: Int) {
-        holder.bind(getItem(position), onClickItem = { onClickItem(it) })
+        holder.bind(
+            getItem(position),
+            onClickItem = { onClickItem(it) },
+            onClickCartButton = {},
+            onClickCheckButton = {}
+        )
     }
 
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentItemViewHolder.kt
@@ -10,11 +10,13 @@ class RecentItemViewHolder(private val binding: ItemRecentBinding) :
     fun bind(
         recent: Recent,
         isPreview: Boolean = true,
+        onClickItem: (recent: Recent) -> Unit,
         onClickCartButton: (recent: Recent) -> Unit = {}
     ) {
         binding.isPreview = isPreview
         binding.recent = recent
 
         binding.ivCart.setOnClickListener { onClickCartButton(recent) }
+        binding.root.setOnClickListener { onClickItem(recent) }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentItemViewHolder.kt
@@ -11,12 +11,14 @@ class RecentItemViewHolder(private val binding: ItemRecentBinding) :
         recent: Recent,
         isPreview: Boolean = true,
         onClickItem: (recent: Recent) -> Unit,
-        onClickCartButton: (recent: Recent) -> Unit = {}
+        onClickCartButton: (recent: Recent) -> Unit = {},
+        onClickCheckButton: (recent: Recent) -> Unit = {}
     ) {
         binding.isPreview = isPreview
         binding.recent = recent
 
         binding.ivCart.setOnClickListener { onClickCartButton(recent) }
+        binding.ivCheck.setOnClickListener { onClickCheckButton(recent) }
         binding.root.setOnClickListener { onClickItem(recent) }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentPreviewViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/RecentPreviewViewHolder.kt
@@ -8,6 +8,7 @@ import com.woowa.banchan.ui.cart.cart.adapter.RecentPreviewRVAdapter
 
 class RecentPreviewViewHolder(
     private val binding: ItemRecentPreviewBinding,
+    private val onClickRecentItem: (recent: Recent) -> Unit,
     private val onClickAllRecentlyViewed: () -> Unit = {}
 ) :
     RecyclerView.ViewHolder(binding.root) {
@@ -18,7 +19,7 @@ class RecentPreviewViewHolder(
         binding.tvEmptyNotice.isVisible = recentList.isEmpty()
         val list = mutableListOf<Recent>()
         recentList.forEachIndexed { index, recent -> if (index < maxCount) list.add(recent) }
-        val adapter = RecentPreviewRVAdapter()
+        val adapter = RecentPreviewRVAdapter(onClickRecentItem)
         adapter.submitList(list)
         binding.rvRecentPreview.adapter = adapter
         binding.tvAllRecent.setOnClickListener { onClickAllRecentlyViewed() }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/RecentFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/RecentFragment.kt
@@ -60,6 +60,10 @@ class RecentFragment : Fragment() {
                 this@RecentFragment.requireActivity().finish()
             }
 
+            override fun onClickCheckButton(recent: Recent) {
+                viewModel.deleteCart(recent)
+            }
+
             override fun onClickCartButton(recent: Recent) {
                 CartAddFragment(recent.toFoodItem()).show(
                     childFragmentManager,
@@ -76,6 +80,15 @@ class RecentFragment : Fragment() {
                 when (it) {
                     is UiState.Success -> adapter.setPreviewList(it.data)
                     is UiState.Error -> showToast(null)
+                    else -> {}
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+
+        viewModel.cartUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach {
+                when (it) {
+                    is UiState.Success -> adapter.setCartList(it.data.values.toList())
+                    is UiState.Error -> showToast(it.message)
                     else -> {}
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/RecentFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/RecentFragment.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.ui.cart.recent
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,6 +17,7 @@ import com.woowa.banchan.ui.cart.CartViewModel
 import com.woowa.banchan.ui.cart.recent.adapter.RecentRVAdapter
 import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.ui.detail.DetailActivity
 import com.woowa.banchan.utils.showToast
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -46,6 +48,18 @@ class RecentFragment : Fragment() {
 
     private fun initListener() {
         val listener = object : RecentRVAdapter.RecentlyViewedCallBackListener {
+
+            override fun onClickItem(recent: Recent) {
+                val intent =
+                    Intent(this@RecentFragment.requireActivity(), DetailActivity::class.java)
+                with(intent) {
+                    putExtra("title", recent.title)
+                    putExtra("hash", recent.hash)
+                }
+                startActivity(intent)
+                this@RecentFragment.requireActivity().finish()
+            }
+
             override fun onClickCartButton(recent: Recent) {
                 CartAddFragment(recent.toFoodItem()).show(
                     childFragmentManager,

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.woowa.banchan.databinding.ItemRecentBinding
+import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.Recent
 import com.woowa.banchan.ui.cart.cart.adapter.viewholder.RecentItemViewHolder
 
@@ -27,8 +28,30 @@ class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
             getItem(position),
             isPreview = false,
             onClickItem = { onClickItem(it) },
-            onClickCartButton = { onClickCartButton(it) }
+            onClickCartButton = { onClickCartButton(it) },
+            onClickCheckButton = { onClickCheckButton(it) }
         )
+    }
+
+    fun setCartList(cartItems: List<Cart>) {
+        val list = currentList.toMutableList()
+        list.forEachIndexed { index, it ->
+            var isInCart = false
+            for (item in cartItems) {
+                if (item.hash == it.hash) {
+                    isInCart = true
+                    if (it.checkState.not()) {
+                        it.checkState = true
+                        notifyItemChanged(index)
+                        break
+                    }
+                }
+            }
+            if (!isInCart && it.checkState) {
+                it.checkState = false
+                notifyItemChanged(index)
+            }
+        }
     }
 
     fun setPreviewList(recentItems: List<Recent>) {
@@ -37,6 +60,10 @@ class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
 
     private fun onClickItem(recent: Recent) {
         listener?.onClickItem(recent)
+    }
+
+    private fun onClickCheckButton(recent: Recent) {
+        listener?.onClickCheckButton(recent)
     }
 
     private fun onClickCartButton(recent: Recent) {
@@ -63,6 +90,7 @@ class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
     interface RecentlyViewedCallBackListener {
 
         fun onClickCartButton(recent: Recent)
+        fun onClickCheckButton(recent: Recent)
         fun onClickItem(recent: Recent)
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
@@ -78,11 +78,11 @@ class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
 
         val diffUtil = object : DiffUtil.ItemCallback<Recent>() {
             override fun areItemsTheSame(oldItem: Recent, newItem: Recent): Boolean {
-                return oldItem == newItem
+                return oldItem.hash == newItem.hash
             }
 
             override fun areContentsTheSame(oldItem: Recent, newItem: Recent): Boolean {
-                return oldItem.hash == newItem.hash
+                return oldItem == newItem
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/recent/adapter/RecentRVAdapter.kt
@@ -23,11 +23,20 @@ class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
     }
 
     override fun onBindViewHolder(holder: RecentItemViewHolder, position: Int) {
-        holder.bind(getItem(position), isPreview = false) { this.onClickCartButton(it) }
+        holder.bind(
+            getItem(position),
+            isPreview = false,
+            onClickItem = { onClickItem(it) },
+            onClickCartButton = { onClickCartButton(it) }
+        )
     }
 
     fun setPreviewList(recentItems: List<Recent>) {
         submitList(recentItems)
+    }
+
+    private fun onClickItem(recent: Recent) {
+        listener?.onClickItem(recent)
     }
 
     private fun onClickCartButton(recent: Recent) {
@@ -54,5 +63,6 @@ class RecentRVAdapter : ListAdapter<Recent, RecentItemViewHolder>(diffUtil) {
     interface RecentlyViewedCallBackListener {
 
         fun onClickCartButton(recent: Recent)
+        fun onClickItem(recent: Recent)
     }
 }

--- a/app/src/main/res/layout/item_recent.xml
+++ b/app/src/main/res/layout/item_recent.xml
@@ -42,10 +42,23 @@
             android:focusable="true"
             android:padding="8dp"
             android:src="@drawable/ic_cart"
-            android:visibility="@{isPreview ? View.GONE : View.VISIBLE}"
+            android:visibility="@{(isPreview||recent.checkState) ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
-F
+
+        <ImageView
+            android:id="@+id/iv_check"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_margin="8dp"
+            android:background="@drawable/background_circle_accent"
+            android:elevation="8dp"
+            android:padding="8dp"
+            android:src="@drawable/ic_check_white"
+            android:visibility="@{(!isPreview &amp;&amp; recent.checkState) ? View.VISIBLE : View.GONE}"
+            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
+            app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
+
         <TextView
             android:id="@+id/tv_title"
             style="@style/bold_14"


### PR DESCRIPTION
### ❗️ 이슈
- close #76 

### 📝 구현한 내용
- 클릭 리스너를 추가해서 Detail 화면으로 이동한다.
- 최근 본 상품 클릭 시 Detail 화면 이동
  -  최근 본 상품 테이블 갱신 시점 구현
    - 데이터들을 불러올 때 24시간 전인 데이터들은 그 순간 delete 요청을 수행해 갱신한다.
- 장바구니 아이콘 표시 적용
  - 최근 본 상품에서 장바구니에 있는 아이템에 대해 체크 표시
  - 체크 클릭 시 삭제 기능 구현
- +추가
  - DataSource와 Repository의 역할 재정의
    - DataSource는 데이터를 가져오고 전달하는 역할의 객체로 둔다.
    - Repository에서 필요로되는 데이터를 파싱하고 적절한 데이터를 전달한다.
    - 이 역할을 다시 정의하며 코드를 수정한다.
  - 할인율 음수값이 나오는 버그를 수정함
  - DiffUtil item 비교 수정
    - areItemsTheSame에서 아이템의 고유 넘버를 비교하고
    - areContentsTheSame에서 아이템 전체 정보를 비교해서 정렬을 하는데 이를 제대로 이용하지 않음
    - 이에 대한 코드를 수정함