### PR TITLE
fix: Food Item 갱신 버그 수정

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseFragment.kt
@@ -14,6 +14,7 @@ import com.woowa.banchan.R
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.bottomsheet.CartAddFragment
 import com.woowa.banchan.ui.detail.DetailActivity
+import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 
 abstract class HomeBaseFragment<T : ViewDataBinding>(@LayoutRes val layoutRes: Int) : Fragment() {
 
@@ -33,6 +34,10 @@ abstract class HomeBaseFragment<T : ViewDataBinding>(@LayoutRes val layoutRes: I
             viewModel.deleteCart(food.detailHash)
         else
             CartAddFragment(food).show(childFragmentManager, getString(R.string.fragment_cart_add))
+    }
+
+    val homeRVAdapter: HomeRVAdapter by lazy {
+        HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseFragment.kt
@@ -2,7 +2,6 @@ package com.woowa.banchan.ui.home
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeBaseViewModel.kt
@@ -16,6 +16,7 @@ abstract class HomeBaseViewModel : ViewModel() {
 
     @Inject
     lateinit var deleteCartUseCase: DeleteCartUseCase
+
     @Inject
     lateinit var getFoodsUseCase: GetFoodsUseCase
 
@@ -26,6 +27,8 @@ abstract class HomeBaseViewModel : ViewModel() {
     val itemUiState: StateFlow<UiState<List<FoodItem>>> get() = _itemUiState.asStateFlow()
 
     private var defaultFoods = emptyList<FoodItem>()
+
+    var spinnerPosition = 0
 
     fun deleteCart(hash: String) {
         viewModelScope.launch {
@@ -38,15 +41,18 @@ abstract class HomeBaseViewModel : ViewModel() {
     fun getFoods(type: String) {
         viewModelScope.launch {
             getFoodsUseCase(type).collect { uiState ->
-                if (uiState is UiState.Success)
+                if (uiState is UiState.Success) {
                     defaultFoods = uiState.data
-                _itemUiState.emit(uiState)
+                    sortList()
+                } else{
+                    _itemUiState.emit(uiState)
+                }
             }
         }
     }
 
-    fun sortList(position: Int) {
-        val sortedList = when (position) {
+    fun sortList() {
+        val sortedList = when (spinnerPosition) {
             0 -> defaultFoods
             1 -> defaultFoods.sortedByDescending { food -> food.sPrice }
             2 -> defaultFoods.sortedBy { food -> food.sPrice }

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeRVTag.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeRVTag.kt
@@ -7,3 +7,24 @@ const val HOME_ITEM = 3
 const val LINEAR_VERTICAL = 4
 const val LINEAR_HORIZONTAL = 5
 const val GRID = 6
+
+sealed class RecyclerViewItem {
+    abstract val id: Int
+
+    object Header : RecyclerViewItem() {
+        override val id = 0
+    }
+
+    object SubHeader : RecyclerViewItem() {
+        override val id = 1
+    }
+
+    data class Item<T>(val item: T) : RecyclerViewItem() { // 아이템 항목
+        override val id = 2
+    }
+
+    object Empty : RecyclerViewItem() {
+        override val id = Integer.MAX_VALUE
+    }
+
+}

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeRVTag.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeRVTag.kt
@@ -8,22 +8,22 @@ const val LINEAR_VERTICAL = 4
 const val LINEAR_HORIZONTAL = 5
 const val GRID = 6
 
-sealed class RecyclerViewItem {
+sealed class RVItem {
     abstract val id: Int
 
-    object Header : RecyclerViewItem() {
+    object Header : RVItem() {
         override val id = 0
     }
 
-    object SubHeader : RecyclerViewItem() {
+    object SubHeader : RVItem() {
         override val id = 1
     }
 
-    data class Item<T>(val item: T) : RecyclerViewItem() { // 아이템 항목
+    data class Item<T>(val item: T) : RVItem() { // 아이템 항목
         override val id = 2
     }
 
-    object Empty : RecyclerViewItem() {
+    object Empty : RVItem() {
         override val id = Integer.MAX_VALUE
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.ui.home.adapter
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -44,7 +43,7 @@ class HomeRVAdapter(
     }
 
     override fun onBindViewHolder(holder: HomeItemViewHolder, position: Int, payloads: MutableList<Any>) {
-        if(payloads.isEmpty()) {
+        if (payloads.isEmpty()) {
             super.onBindViewHolder(holder, position, payloads)
         } else {
             holder.bind(getItem(position))
@@ -63,7 +62,7 @@ class HomeRVAdapter(
             }
 
             override fun getChangePayload(oldItem: FoodItem, newItem: FoodItem): Any? {
-                if(oldItem.checkState != newItem.checkState) {
+                if (oldItem.checkState != newItem.checkState) {
                     return true
                 }
                 return super.getChangePayload(oldItem, newItem)

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.ui.home.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -54,8 +55,6 @@ class HomeRVAdapter(
 
         val diffUtil = object : DiffUtil.ItemCallback<FoodItem>() {
             override fun areItemsTheSame(oldItem: FoodItem, newItem: FoodItem): Boolean {
-                if(oldItem.detailHash != newItem.detailHash) {
-                }
                 return oldItem.detailHash == newItem.detailHash
             }
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/HomeRVAdapter.kt
@@ -42,15 +42,32 @@ class HomeRVAdapter(
         holder.bind(getItem(position), itemClickListener, cartClickListener)
     }
 
+    override fun onBindViewHolder(holder: HomeItemViewHolder, position: Int, payloads: MutableList<Any>) {
+        if(payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            holder.bind(getItem(position))
+        }
+    }
+
     companion object {
 
         val diffUtil = object : DiffUtil.ItemCallback<FoodItem>() {
             override fun areItemsTheSame(oldItem: FoodItem, newItem: FoodItem): Boolean {
-                return oldItem == newItem
+                if(oldItem.detailHash != newItem.detailHash) {
+                }
+                return oldItem.detailHash == newItem.detailHash
             }
 
             override fun areContentsTheSame(oldItem: FoodItem, newItem: FoodItem): Boolean {
-                return oldItem.detailHash == newItem.detailHash
+                return oldItem == newItem
+            }
+
+            override fun getChangePayload(oldItem: FoodItem, newItem: FoodItem): Any? {
+                if(oldItem.checkState != newItem.checkState) {
+                    return true
+                }
+                return super.getChangePayload(oldItem, newItem)
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
@@ -49,15 +49,10 @@ class SoupSideRVAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        when (holder.itemViewType) {
-            HOME_HEADER -> (holder as HomeHeaderViewHolder).bind(
-                if (isSoup)
-                    "정성이 담긴\n뜨끈뜨끈 국물 요리"
-                else
-                    "식탁을 풍성하게 하는\n정갈한 밑반찬", false
-            )
-            SUB_HEADER -> (holder as SoupSideHeaderViewHolder).bind(homeRVAdapter.itemCount, spinnerCallback)
-            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter)
+        when (holder) {
+            is HomeHeaderViewHolder -> holder.bind(if (isSoup) "정성이 담긴\n뜨끈뜨끈 국물 요리" else "식탁을 풍성하게 하는\n정갈한 밑반찬", false)
+            is SoupSideHeaderViewHolder -> holder.bind(homeRVAdapter.itemCount, spinnerCallback)
+            is HomeRecyclerViewViewHolder -> holder.bind(homeRVAdapter)
         }
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
@@ -9,7 +9,10 @@ import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemSoupSideHeaderBinding
 import com.woowa.banchan.domain.model.FoodItem
-import com.woowa.banchan.ui.home.*
+import com.woowa.banchan.ui.home.HOME_HEADER
+import com.woowa.banchan.ui.home.HOME_ITEM
+import com.woowa.banchan.ui.home.RVItem
+import com.woowa.banchan.ui.home.SUB_HEADER
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.soupside.viewholder.SoupSideHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
@@ -17,6 +20,7 @@ import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
 
 class SoupSideRVAdapter(
     private val isSoup: Boolean,
+    private val spinnerPosition: Int,
     private val spinnerCallback: (Int) -> Unit,
     private val homeRVAdapter: HomeRVAdapter
 ) :
@@ -51,7 +55,7 @@ class SoupSideRVAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is HomeHeaderViewHolder -> holder.bind(if (isSoup) "정성이 담긴\n뜨끈뜨끈 국물 요리" else "식탁을 풍성하게 하는\n정갈한 밑반찬", false)
-            is SoupSideHeaderViewHolder -> holder.bind(homeRVAdapter.itemCount, spinnerCallback)
+            is SoupSideHeaderViewHolder -> holder.bind(homeRVAdapter.itemCount, spinnerPosition, spinnerCallback)
             is HomeRecyclerViewViewHolder -> holder.bind(homeRVAdapter)
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
@@ -18,13 +18,9 @@ import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
 class SoupSideRVAdapter(
     private val isSoup: Boolean,
     private val spinnerCallback: (Int) -> Unit,
-    itemClickListener: (String, String) -> Unit,
-    cartClickListener: (FoodItem) -> Unit
+    private val homeRVAdapter: HomeRVAdapter
 ) :
     ListAdapter<RVItem, RecyclerView.ViewHolder>(diffUtil) {
-
-    var managerType = GRID
-    private val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
@@ -60,8 +56,8 @@ class SoupSideRVAdapter(
                 else
                     "식탁을 풍성하게 하는\n정갈한 밑반찬", false
             )
-            SUB_HEADER -> (holder as SoupSideHeaderViewHolder).bind((getItem(2) as RVItem.Item<List<FoodItem>>).item.size, spinnerCallback)
-            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter, (getItem(2) as RVItem.Item<List<FoodItem>>).item, managerType)
+            SUB_HEADER -> (holder as SoupSideHeaderViewHolder).bind(homeRVAdapter.itemCount, spinnerCallback)
+            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter)
         }
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
@@ -9,10 +9,7 @@ import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemSoupSideHeaderBinding
 import com.woowa.banchan.domain.model.FoodItem
-import com.woowa.banchan.ui.home.GRID
-import com.woowa.banchan.ui.home.HOME_HEADER
-import com.woowa.banchan.ui.home.HOME_ITEM
-import com.woowa.banchan.ui.home.SUB_HEADER
+import com.woowa.banchan.ui.home.*
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.soupside.viewholder.SoupSideHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
@@ -24,7 +21,7 @@ class SoupSideRVAdapter(
     itemClickListener: (String, String) -> Unit,
     cartClickListener: (FoodItem) -> Unit
 ) :
-    ListAdapter<List<FoodItem>, RecyclerView.ViewHolder>(diffUtil) {
+    ListAdapter<RVItem, RecyclerView.ViewHolder>(diffUtil) {
 
     var managerType = GRID
     private val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
@@ -63,8 +60,8 @@ class SoupSideRVAdapter(
                 else
                     "식탁을 풍성하게 하는\n정갈한 밑반찬", false
             )
-            SUB_HEADER -> (holder as SoupSideHeaderViewHolder).bind(getItem(2).size, spinnerCallback)
-            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter, getItem(position), managerType)
+            SUB_HEADER -> (holder as SoupSideHeaderViewHolder).bind((getItem(2) as RVItem.Item<List<FoodItem>>).item.size, spinnerCallback)
+            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter, (getItem(2) as RVItem.Item<List<FoodItem>>).item, managerType)
         }
     }
 
@@ -77,21 +74,21 @@ class SoupSideRVAdapter(
     }
 
     fun submitHeaderList(food: List<FoodItem>) {
-        val newList = mutableListOf<List<FoodItem>?>()
-        newList.add(null)
-        newList.add(null)
-        newList.add(food)
+        val newList = mutableListOf<RVItem>()
+        newList.add(RVItem.Header)
+        newList.add(RVItem.SubHeader)
+        newList.add(RVItem.Item(food))
         submitList(newList)
     }
 
     companion object {
 
-        val diffUtil = object : DiffUtil.ItemCallback<List<FoodItem>>() {
-            override fun areItemsTheSame(oldItem: List<FoodItem>, newItem: List<FoodItem>): Boolean {
-                return oldItem.hashCode() == newItem.hashCode()
+        val diffUtil = object : DiffUtil.ItemCallback<RVItem>() {
+            override fun areItemsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
+                return oldItem.id == newItem.id
             }
 
-            override fun areContentsTheSame(oldItem: List<FoodItem>, newItem: List<FoodItem>): Boolean {
+            override fun areContentsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
                 return oldItem == newItem
             }
         }

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/viewholder/SoupSideHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/viewholder/SoupSideHeaderViewHolder.kt
@@ -8,9 +8,11 @@ import com.woowa.banchan.ui.home.main.adapter.SpinnerAdapter
 
 class SoupSideHeaderViewHolder(private val binding: ItemSoupSideHeaderBinding) :
     RecyclerView.ViewHolder(binding.root) {
-    fun bind(count: Int, spinnerCallback: (Int) -> Unit) {
+    fun bind(count: Int, spinnerPosition: Int, spinnerCallback: (Int) -> Unit) {
         val spinnerAdapter = SpinnerAdapter(binding.spinnerSort.context)
+
         binding.spinnerSort.adapter = spinnerAdapter
+        binding.spinnerSort.setSelection(spinnerPosition)
         binding.spinnerSort.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 spinnerAdapter.selectedPosition = position

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
@@ -38,11 +38,10 @@ class HomeItemViewHolder(private val binding: ViewDataBinding) :
     }
 
     fun bind(food: FoodItem) {
-        if(binding is ItemHomeBinding) {
+        if (binding is ItemHomeBinding) {
             binding.food!!.checkState = food.checkState
             binding.checkState = food.checkState
-        }
-        else if(binding is ItemMainLinearBinding) {
+        } else if (binding is ItemMainLinearBinding) {
             binding.food!!.checkState = food.checkState
             binding.checkState = food.checkState
         }

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeItemViewHolder.kt
@@ -12,6 +12,7 @@ class HomeItemViewHolder(private val binding: ViewDataBinding) :
     fun bind(food: FoodItem, itemClickListener: (String, String) -> Unit, cartClickListener: (FoodItem) -> Unit) {
         if (binding is ItemHomeBinding) {
             binding.food = food
+            binding.checkState = food.checkState
             binding.layoutHome.setOnClickListener {
                 itemClickListener(food.title, food.detailHash)
             }
@@ -23,6 +24,7 @@ class HomeItemViewHolder(private val binding: ViewDataBinding) :
             }
         } else if (binding is ItemMainLinearBinding) {
             binding.food = food
+            binding.checkState = food.checkState
             binding.layoutMain.setOnClickListener {
                 itemClickListener(food.title, food.detailHash)
             }
@@ -32,6 +34,17 @@ class HomeItemViewHolder(private val binding: ViewDataBinding) :
             binding.ivCheck.setOnClickListener {
                 cartClickListener(food)
             }
+        }
+    }
+
+    fun bind(food: FoodItem) {
+        if(binding is ItemHomeBinding) {
+            binding.food!!.checkState = food.checkState
+            binding.checkState = food.checkState
+        }
+        else if(binding is ItemMainLinearBinding) {
+            binding.food!!.checkState = food.checkState
+            binding.checkState = food.checkState
         }
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeRecyclerViewViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/viewholder/HomeRecyclerViewViewHolder.kt
@@ -12,9 +12,20 @@ import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 class HomeRecyclerViewViewHolder(private val binding: ItemRecyclerviewBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(homeRVAdapter: HomeRVAdapter, food: List<FoodItem>, managerType: Int) {
+    fun bind(homeRVAdapter: HomeRVAdapter) {
+        initLayoutManager(homeRVAdapter)
+        binding.rvBest.adapter = homeRVAdapter
+    }
+
+    fun bind(homeRVAdapter: HomeRVAdapter, items: List<FoodItem>) {
+        initLayoutManager(homeRVAdapter)
+        binding.rvBest.adapter = homeRVAdapter
+        homeRVAdapter.submitList(items)
+    }
+
+    private fun initLayoutManager(homeRVAdapter: HomeRVAdapter) {
         binding.rvBest.apply {
-            layoutManager = when (managerType) {
+            layoutManager = when (homeRVAdapter.managerType) {
                 LINEAR_HORIZONTAL -> LinearLayoutManager(
                     this.context,
                     LinearLayoutManager.HORIZONTAL,
@@ -28,7 +39,5 @@ class HomeRecyclerViewViewHolder(private val binding: ItemRecyclerviewBinding) :
                 else -> GridLayoutManager(this.context, 2)
             }
         }
-        binding.rvBest.adapter = homeRVAdapter
-        homeRVAdapter.submitList(food)
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -54,7 +54,6 @@ class BestRVAdapter(
             else -> (holder as HomeRecyclerViewViewHolder).bind(
                 HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
                 (getItem(position) as RVItem.Item<BestFoodCategory>).item.items,
-                LINEAR_HORIZONTAL,
             )
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -10,10 +10,7 @@ import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.domain.model.BestFoodCategory
 import com.woowa.banchan.domain.model.FoodItem
-import com.woowa.banchan.ui.home.HOME_HEADER
-import com.woowa.banchan.ui.home.HOME_ITEM
-import com.woowa.banchan.ui.home.LINEAR_HORIZONTAL
-import com.woowa.banchan.ui.home.SUB_HEADER
+import com.woowa.banchan.ui.home.*
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
@@ -22,7 +19,7 @@ import com.woowa.banchan.ui.home.best.adapter.viewholder.BestHeaderViewHolder
 class BestRVAdapter(
     private val itemClickListener: (String, String) -> Unit,
     private val cartClickListener: (FoodItem) -> Unit
-) : ListAdapter<BestFoodCategory, RecyclerView.ViewHolder>(diffUtil) {
+) : ListAdapter<RecyclerViewItem, RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
@@ -53,10 +50,10 @@ class BestRVAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
             HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("한 번 주문하면\n두 번 반하는 반찬들", true)
-            SUB_HEADER -> (holder as BestHeaderViewHolder).bind(getItem(position))
+            SUB_HEADER -> (holder as BestHeaderViewHolder).bind((getItem(position) as RecyclerViewItem.Item<BestFoodCategory>).item)
             else -> (holder as HomeRecyclerViewViewHolder).bind(
                 HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
-                getItem(position).items,
+                (getItem(position) as RecyclerViewItem.Item<BestFoodCategory>).item.items,
                 LINEAR_HORIZONTAL,
             )
         }
@@ -74,30 +71,24 @@ class BestRVAdapter(
     }
 
     fun submitHeaderList(list: List<BestFoodCategory>) {
-        val newList = mutableListOf<BestFoodCategory?>()
-        newList.add(null)
+        val newList = mutableListOf<RecyclerViewItem>()
+        newList.add(RecyclerViewItem.Header)
         for (category in list) {
-            newList.add(category)
-            newList.add(category)
+            newList.add(RecyclerViewItem.Item(category))
+            newList.add(RecyclerViewItem.Item(category))
         }
         submitList(newList)
     }
 
     companion object {
 
-        val diffUtil = object : DiffUtil.ItemCallback<BestFoodCategory>() {
-            override fun areItemsTheSame(
-                oldItem: BestFoodCategory,
-                newItem: BestFoodCategory
-            ): Boolean {
-                return oldItem == newItem
+        val diffUtil = object : DiffUtil.ItemCallback<RecyclerViewItem>() {
+            override fun areItemsTheSame(oldItem: RecyclerViewItem, newItem: RecyclerViewItem): Boolean {
+                return oldItem.id == newItem.id
             }
 
-            override fun areContentsTheSame(
-                oldItem: BestFoodCategory,
-                newItem: BestFoodCategory
-            ): Boolean {
-                return oldItem.categoryId == newItem.categoryId
+            override fun areContentsTheSame(oldItem: RecyclerViewItem, newItem: RecyclerViewItem): Boolean {
+                return oldItem == newItem
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -19,7 +19,7 @@ import com.woowa.banchan.ui.home.best.adapter.viewholder.BestHeaderViewHolder
 class BestRVAdapter(
     private val itemClickListener: (String, String) -> Unit,
     private val cartClickListener: (FoodItem) -> Unit
-) : ListAdapter<RecyclerViewItem, RecyclerView.ViewHolder>(diffUtil) {
+) : ListAdapter<RVItem, RecyclerView.ViewHolder>(diffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
@@ -50,10 +50,10 @@ class BestRVAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
             HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("한 번 주문하면\n두 번 반하는 반찬들", true)
-            SUB_HEADER -> (holder as BestHeaderViewHolder).bind((getItem(position) as RecyclerViewItem.Item<BestFoodCategory>).item)
+            SUB_HEADER -> (holder as BestHeaderViewHolder).bind((getItem(position) as RVItem.Item<BestFoodCategory>).item)
             else -> (holder as HomeRecyclerViewViewHolder).bind(
                 HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
-                (getItem(position) as RecyclerViewItem.Item<BestFoodCategory>).item.items,
+                (getItem(position) as RVItem.Item<BestFoodCategory>).item.items,
                 LINEAR_HORIZONTAL,
             )
         }
@@ -71,23 +71,23 @@ class BestRVAdapter(
     }
 
     fun submitHeaderList(list: List<BestFoodCategory>) {
-        val newList = mutableListOf<RecyclerViewItem>()
-        newList.add(RecyclerViewItem.Header)
+        val newList = mutableListOf<RVItem>()
+        newList.add(RVItem.Header)
         for (category in list) {
-            newList.add(RecyclerViewItem.Item(category))
-            newList.add(RecyclerViewItem.Item(category))
+            newList.add(RVItem.Item(category))
+            newList.add(RVItem.Item(category))
         }
         submitList(newList)
     }
 
     companion object {
 
-        val diffUtil = object : DiffUtil.ItemCallback<RecyclerViewItem>() {
-            override fun areItemsTheSame(oldItem: RecyclerViewItem, newItem: RecyclerViewItem): Boolean {
+        val diffUtil = object : DiffUtil.ItemCallback<RVItem>() {
+            override fun areItemsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
                 return oldItem.id == newItem.id
             }
 
-            override fun areContentsTheSame(oldItem: RecyclerViewItem, newItem: RecyclerViewItem): Boolean {
+            override fun areContentsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
                 return oldItem == newItem
             }
         }

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -48,10 +48,10 @@ class BestRVAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        when (holder.itemViewType) {
-            HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("한 번 주문하면\n두 번 반하는 반찬들", true)
-            SUB_HEADER -> (holder as BestHeaderViewHolder).bind((getItem(position) as RVItem.Item<BestFoodCategory>).item)
-            else -> (holder as HomeRecyclerViewViewHolder).bind(
+        when (holder) {
+            is HomeHeaderViewHolder -> holder.bind("한 번 주문하면\n두 번 반하는 반찬들", true)
+            is BestHeaderViewHolder -> holder.bind((getItem(position) as RVItem.Item<BestFoodCategory>).item)
+            is HomeRecyclerViewViewHolder -> holder.bind(
                 HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = LINEAR_HORIZONTAL },
                 (getItem(position) as RVItem.Item<BestFoodCategory>).item.items,
             )

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
@@ -6,12 +6,10 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMainBinding
-import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.home.GRID
 import com.woowa.banchan.ui.home.HomeBaseFragment
 import com.woowa.banchan.ui.home.LINEAR_VERTICAL
-import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.main.adapter.MainRVAdapter
 import com.woowa.banchan.utils.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,11 +22,12 @@ class MainFragment : HomeBaseFragment<FragmentMainBinding>(R.layout.fragment_mai
     override val viewModel: MainViewModel by viewModels()
 
     private val mainAdapter: MainRVAdapter by lazy {
-        MainRVAdapter(checkedChangeListener, spinnerCallback, homeRVAdapter)
+        MainRVAdapter(checkedChangeListener, viewModel.spinnerPosition, spinnerCallback, homeRVAdapter)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
-        viewModel.sortList(position)
+        viewModel.spinnerPosition = position
+        viewModel.sortList()
     }
 
     private val checkedChangeListener: (RadioGroup, Int) -> Unit = { group, checkedId ->

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/MainFragment.kt
@@ -6,10 +6,12 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMainBinding
+import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.common.uistate.UiState
 import com.woowa.banchan.ui.home.GRID
 import com.woowa.banchan.ui.home.HomeBaseFragment
 import com.woowa.banchan.ui.home.LINEAR_VERTICAL
+import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.main.adapter.MainRVAdapter
 import com.woowa.banchan.utils.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,7 +24,7 @@ class MainFragment : HomeBaseFragment<FragmentMainBinding>(R.layout.fragment_mai
     override val viewModel: MainViewModel by viewModels()
 
     private val mainAdapter: MainRVAdapter by lazy {
-        MainRVAdapter(checkedChangeListener, spinnerCallback, itemClickListener, cartClickListener)
+        MainRVAdapter(checkedChangeListener, spinnerCallback, homeRVAdapter)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
@@ -38,7 +40,7 @@ class MainFragment : HomeBaseFragment<FragmentMainBinding>(R.layout.fragment_mai
                 mainAdapter.managerType = LINEAR_VERTICAL
             }
         }
-        mainAdapter.homeRVAdapter.managerType = mainAdapter.managerType
+        homeRVAdapter.managerType = mainAdapter.managerType
         mainAdapter.notifyItemChanged(2)
     }
 
@@ -54,7 +56,7 @@ class MainFragment : HomeBaseFragment<FragmentMainBinding>(R.layout.fragment_mai
         viewModel.itemUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if (state is UiState.Success) {
-                    mainAdapter.submitHeaderList(state.data)
+                    homeRVAdapter.submitList(state.data)
                 } else if (state is UiState.Error) {
                     showToast(state.message)
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -20,16 +20,13 @@ import com.woowa.banchan.ui.home.main.adapter.viewholder.MainHeaderViewHolder
 class MainRVAdapter(
     private val checkedChangeListener: (RadioGroup, Int) -> Unit,
     private val spinnerCallback: (Int) -> Unit,
-    itemClickListener: (String, String) -> Unit,
-    cartClickListener: (FoodItem) -> Unit
+    private val homeRVAdapter: HomeRVAdapter,
 ) :
     ListAdapter<RVItem, RecyclerView.ViewHolder>(diffUtil) {
 
     var managerType = GRID
-    val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        Log.d("Test","MainRVAdapter")
         return when (viewType) {
             HOME_HEADER -> HomeHeaderViewHolder(
                 ItemHomeHeaderBinding.inflate(
@@ -59,7 +56,7 @@ class MainRVAdapter(
         when (holder) {
             is HomeHeaderViewHolder -> holder.bind("모두가 좋아하는\n든든한 메인 요리", false)
             is MainHeaderViewHolder -> holder.bind(checkedChangeListener, spinnerCallback)
-            is HomeRecyclerViewViewHolder -> holder.bind(homeRVAdapter, (getItem(position) as RVItem.Item<List<FoodItem>>).item, managerType)
+            is HomeRecyclerViewViewHolder -> holder.bind(homeRVAdapter)
         }
     }
 
@@ -70,6 +67,8 @@ class MainRVAdapter(
             else -> HOME_ITEM
         }
     }
+
+    override fun getItemCount(): Int = 3
 
     fun submitHeaderList(food: List<FoodItem>) {
         val newList = mutableListOf<RVItem>()

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.ui.home.main.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.RadioGroup
@@ -28,6 +29,7 @@ class MainRVAdapter(
     val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        Log.d("Test","MainRVAdapter")
         return when (viewType) {
             HOME_HEADER -> HomeHeaderViewHolder(
                 ItemHomeHeaderBinding.inflate(
@@ -54,10 +56,10 @@ class MainRVAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        when (holder.itemViewType) {
-            HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("모두가 좋아하는\n든든한 메인 요리", false)
-            SUB_HEADER -> (holder as MainHeaderViewHolder).bind(checkedChangeListener, spinnerCallback)
-            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter, (getItem(position) as RVItem.Item<List<FoodItem>>).item, managerType)
+        when (holder) {
+            is HomeHeaderViewHolder -> holder.bind("모두가 좋아하는\n든든한 메인 요리", false)
+            is MainHeaderViewHolder -> holder.bind(checkedChangeListener, spinnerCallback)
+            is HomeRecyclerViewViewHolder -> holder.bind(homeRVAdapter, (getItem(position) as RVItem.Item<List<FoodItem>>).item, managerType)
         }
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -17,6 +17,7 @@ import com.woowa.banchan.ui.home.main.adapter.viewholder.MainHeaderViewHolder
 
 class MainRVAdapter(
     private val checkedChangeListener: (RadioGroup, Int) -> Unit,
+    private val spinnerPosition: Int,
     private val spinnerCallback: (Int) -> Unit,
     private val homeRVAdapter: HomeRVAdapter,
 ) :
@@ -53,7 +54,7 @@ class MainRVAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is HomeHeaderViewHolder -> holder.bind("모두가 좋아하는\n든든한 메인 요리", false)
-            is MainHeaderViewHolder -> holder.bind(checkedChangeListener, spinnerCallback)
+            is MainHeaderViewHolder -> holder.bind(spinnerPosition, checkedChangeListener, spinnerCallback)
             is HomeRecyclerViewViewHolder -> holder.bind(homeRVAdapter)
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.ui.home.main.adapter
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.RadioGroup
@@ -10,7 +9,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemMainHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
-import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.home.*
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
@@ -69,14 +67,6 @@ class MainRVAdapter(
     }
 
     override fun getItemCount(): Int = 3
-
-    fun submitHeaderList(food: List<FoodItem>) {
-        val newList = mutableListOf<RVItem>()
-        newList.add(RVItem.Header)
-        newList.add(RVItem.SubHeader)
-        newList.add(RVItem.Item(food))
-        submitList(newList)
-    }
 
     companion object {
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -10,10 +10,7 @@ import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemMainHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.domain.model.FoodItem
-import com.woowa.banchan.ui.home.GRID
-import com.woowa.banchan.ui.home.HOME_HEADER
-import com.woowa.banchan.ui.home.HOME_ITEM
-import com.woowa.banchan.ui.home.SUB_HEADER
+import com.woowa.banchan.ui.home.*
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder
@@ -25,7 +22,7 @@ class MainRVAdapter(
     itemClickListener: (String, String) -> Unit,
     cartClickListener: (FoodItem) -> Unit
 ) :
-    ListAdapter<List<FoodItem>, RecyclerView.ViewHolder>(diffUtil) {
+    ListAdapter<RVItem, RecyclerView.ViewHolder>(diffUtil) {
 
     var managerType = GRID
     val homeRVAdapter: HomeRVAdapter = HomeRVAdapter(itemClickListener, cartClickListener).apply { managerType = GRID }
@@ -60,7 +57,7 @@ class MainRVAdapter(
         when (holder.itemViewType) {
             HOME_HEADER -> (holder as HomeHeaderViewHolder).bind("모두가 좋아하는\n든든한 메인 요리", false)
             SUB_HEADER -> (holder as MainHeaderViewHolder).bind(checkedChangeListener, spinnerCallback)
-            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter, getItem(position), managerType)
+            else -> (holder as HomeRecyclerViewViewHolder).bind(homeRVAdapter, (getItem(position) as RVItem.Item<List<FoodItem>>).item, managerType)
         }
     }
 
@@ -73,21 +70,21 @@ class MainRVAdapter(
     }
 
     fun submitHeaderList(food: List<FoodItem>) {
-        val newList = mutableListOf<List<FoodItem>?>()
-        newList.add(null)
-        newList.add(null)
-        newList.add(food)
+        val newList = mutableListOf<RVItem>()
+        newList.add(RVItem.Header)
+        newList.add(RVItem.SubHeader)
+        newList.add(RVItem.Item(food))
         submitList(newList)
     }
 
     companion object {
 
-        val diffUtil = object : DiffUtil.ItemCallback<List<FoodItem>>() {
-            override fun areItemsTheSame(oldItem: List<FoodItem>, newItem: List<FoodItem>): Boolean {
-                return oldItem == newItem
+        val diffUtil = object : DiffUtil.ItemCallback<RVItem>() {
+            override fun areItemsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
+                return oldItem.id == newItem.id
             }
 
-            override fun areContentsTheSame(oldItem: List<FoodItem>, newItem: List<FoodItem>): Boolean {
+            override fun areContentsTheSame(oldItem: RVItem, newItem: RVItem): Boolean {
                 return oldItem == newItem
             }
         }

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/viewholder/MainHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/viewholder/MainHeaderViewHolder.kt
@@ -9,9 +9,10 @@ import com.woowa.banchan.ui.home.main.adapter.SpinnerAdapter
 
 class MainHeaderViewHolder(private val binding: ItemMainHeaderBinding) :
     RecyclerView.ViewHolder(binding.root) {
-    fun bind(checkedChangeListener: (RadioGroup, Int) -> Unit, spinnerCallback: (Int) -> Unit) {
+    fun bind(spinnerPosition: Int, checkedChangeListener: (RadioGroup, Int) -> Unit, spinnerCallback: (Int) -> Unit) {
         val spinnerAdapter = SpinnerAdapter(binding.spinnerSort.context)
         binding.spinnerSort.adapter = spinnerAdapter
+        binding.spinnerSort.setSelection(spinnerPosition)
         binding.spinnerSort.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 spinnerAdapter.selectedPosition = position

--- a/app/src/main/java/com/woowa/banchan/ui/home/side/SideFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/side/SideFragment.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSideBinding
 import com.woowa.banchan.ui.common.uistate.UiState
-import com.woowa.banchan.ui.home.GRID
 import com.woowa.banchan.ui.home.HomeBaseFragment
 import com.woowa.banchan.ui.home.adapter.soupside.SoupSideRVAdapter
 import com.woowa.banchan.utils.showToast
@@ -20,11 +19,12 @@ class SideFragment : HomeBaseFragment<FragmentSideBinding>(R.layout.fragment_sid
     override val viewModel: SideViewModel by viewModels()
 
     private val soupSideAdapter: SoupSideRVAdapter by lazy {
-        SoupSideRVAdapter(false, spinnerCallback, homeRVAdapter)
+        SoupSideRVAdapter(false, viewModel.spinnerPosition, spinnerCallback, homeRVAdapter)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
-        viewModel.sortList(position)
+        viewModel.spinnerPosition = position
+        viewModel.sortList()
     }
 
     override fun initAdapter() {
@@ -39,7 +39,7 @@ class SideFragment : HomeBaseFragment<FragmentSideBinding>(R.layout.fragment_sid
         viewModel.itemUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if (state is UiState.Success) {
-                    if(homeRVAdapter.itemCount == 0)
+                    if (homeRVAdapter.itemCount == 0)
                         soupSideAdapter.submitHeaderList(state.data)
                     homeRVAdapter.submitList(state.data)
                 } else if (state is UiState.Error) {

--- a/app/src/main/java/com/woowa/banchan/ui/home/side/SideFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/side/SideFragment.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSideBinding
 import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.ui.home.GRID
 import com.woowa.banchan.ui.home.HomeBaseFragment
 import com.woowa.banchan.ui.home.adapter.soupside.SoupSideRVAdapter
 import com.woowa.banchan.utils.showToast
@@ -19,7 +20,7 @@ class SideFragment : HomeBaseFragment<FragmentSideBinding>(R.layout.fragment_sid
     override val viewModel: SideViewModel by viewModels()
 
     private val soupSideAdapter: SoupSideRVAdapter by lazy {
-        SoupSideRVAdapter(false, spinnerCallback, itemClickListener, cartClickListener)
+        SoupSideRVAdapter(false, spinnerCallback, homeRVAdapter)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
@@ -38,7 +39,9 @@ class SideFragment : HomeBaseFragment<FragmentSideBinding>(R.layout.fragment_sid
         viewModel.itemUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if (state is UiState.Success) {
-                    soupSideAdapter.submitHeaderList(state.data)
+                    if(homeRVAdapter.itemCount == 0)
+                        soupSideAdapter.submitHeaderList(state.data)
+                    homeRVAdapter.submitList(state.data)
                 } else if (state is UiState.Error) {
                     showToast(state.message)
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSoupBinding
 import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.ui.home.GRID
 import com.woowa.banchan.ui.home.HomeBaseFragment
 import com.woowa.banchan.ui.home.adapter.soupside.SoupSideRVAdapter
 import com.woowa.banchan.utils.showToast
@@ -18,8 +19,8 @@ class SoupFragment : HomeBaseFragment<FragmentSoupBinding>(R.layout.fragment_sou
 
     override val viewModel: SoupViewModel by viewModels()
 
-    private val soupAdapter: SoupSideRVAdapter by lazy {
-        SoupSideRVAdapter(true, spinnerCallback, itemClickListener, cartClickListener)
+    private val soupSideAdapter: SoupSideRVAdapter by lazy {
+        SoupSideRVAdapter(false, spinnerCallback, homeRVAdapter)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
@@ -27,7 +28,7 @@ class SoupFragment : HomeBaseFragment<FragmentSoupBinding>(R.layout.fragment_sou
     }
 
     override fun initAdapter() {
-        binding.rvSoup.adapter = soupAdapter
+        binding.rvSoup.adapter = soupSideAdapter
     }
 
     override fun initViews() {
@@ -38,7 +39,9 @@ class SoupFragment : HomeBaseFragment<FragmentSoupBinding>(R.layout.fragment_sou
         viewModel.itemUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if (state is UiState.Success) {
-                    soupAdapter.submitHeaderList(state.data)
+                    if(homeRVAdapter.itemCount == 0)
+                        soupSideAdapter.submitHeaderList(state.data)
+                    homeRVAdapter.submitList(state.data)
                 } else if (state is UiState.Error) {
                     showToast(state.message)
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/soup/SoupFragment.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.lifecycleScope
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSoupBinding
 import com.woowa.banchan.ui.common.uistate.UiState
-import com.woowa.banchan.ui.home.GRID
 import com.woowa.banchan.ui.home.HomeBaseFragment
 import com.woowa.banchan.ui.home.adapter.soupside.SoupSideRVAdapter
 import com.woowa.banchan.utils.showToast
@@ -20,11 +19,12 @@ class SoupFragment : HomeBaseFragment<FragmentSoupBinding>(R.layout.fragment_sou
     override val viewModel: SoupViewModel by viewModels()
 
     private val soupSideAdapter: SoupSideRVAdapter by lazy {
-        SoupSideRVAdapter(false, spinnerCallback, homeRVAdapter)
+        SoupSideRVAdapter(false, viewModel.spinnerPosition, spinnerCallback, homeRVAdapter)
     }
 
     private val spinnerCallback: (Int) -> Unit = { position ->
-        viewModel.sortList(position)
+        viewModel.spinnerPosition = position
+        viewModel.sortList()
     }
 
     override fun initAdapter() {
@@ -39,7 +39,7 @@ class SoupFragment : HomeBaseFragment<FragmentSoupBinding>(R.layout.fragment_sou
         viewModel.itemUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { state ->
                 if (state is UiState.Success) {
-                    if(homeRVAdapter.itemCount == 0)
+                    if (homeRVAdapter.itemCount == 0)
                         soupSideAdapter.submitHeaderList(state.data)
                     homeRVAdapter.submitList(state.data)
                 } else if (state is UiState.Error) {

--- a/app/src/main/res/layout/item_home.xml
+++ b/app/src/main/res/layout/item_home.xml
@@ -9,6 +9,10 @@
             name="food"
             type="com.woowa.banchan.domain.model.FoodItem" />
 
+        <variable
+            name="checkState"
+            type="Boolean" />
+
         <import type="android.view.View" />
 
     </data>
@@ -37,7 +41,7 @@
             android:elevation="8dp"
             android:padding="8dp"
             android:src="@drawable/ic_cart"
-            android:visibility="@{food.checkState ? View.GONE : View.VISIBLE}"
+            android:visibility="@{checkState ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
 
@@ -50,7 +54,7 @@
             android:elevation="8dp"
             android:padding="8dp"
             android:src="@drawable/ic_check_white"
-            android:visibility="@{food.checkState ? View.VISIBLE : View.GONE}"
+            android:visibility="@{checkState ? View.VISIBLE : View.GONE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
 

--- a/app/src/main/res/layout/item_main_linear.xml
+++ b/app/src/main/res/layout/item_main_linear.xml
@@ -9,6 +9,10 @@
             name="food"
             type="com.woowa.banchan.domain.model.FoodItem" />
 
+        <variable
+            name="checkState"
+            type="Boolean" />
+
         <import type="android.view.View" />
 
     </data>
@@ -37,7 +41,7 @@
             android:elevation="8dp"
             android:padding="8dp"
             android:src="@drawable/ic_cart"
-            android:visibility="@{food.checkState ? View.GONE : View.VISIBLE}"
+            android:visibility="@{checkState ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
 
@@ -50,7 +54,7 @@
             android:elevation="8dp"
             android:padding="8dp"
             android:src="@drawable/ic_check_white"
-            android:visibility="@{food.checkState ? View.VISIBLE : View.GONE}"
+            android:visibility="@{checkState ? View.VISIBLE : View.GONE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toEndOf="@id/iv_thumbnail" />
 


### PR DESCRIPTION
### ❗️ 이슈
- close #74 

### 📝 구현한 내용
- 아이템이 갱신될 때 스크롤이 최상단으로 올라가지 않게 한다.
- 정렬 상태가 유지되도록 한다.
- 페이로드를 활용하여 체크표시만 전환되게 한다.

### ❓ 고민한 내용
- header와 subheader가 갱신 안 되게 하는 방법은 없을까?
  -  SealedClass로 임의의 id를 지정해주어 DiffUtil이 정상작동 되도록 해결
  - 기존에는 null값을 삽입해주었기 때문에 DiffUtil이 제 기능을 하지 못 하여 아이템이 전체 갱신돼서 스크롤이 위로 올라가는 거였음

- Cart의 상태가 바뀔 때 카트아이콘만 바뀌게 하기
  - payload를 구현하였습니다.
  - 저희의 현재 RecyclerView는 Main 탭을 예로 들면 MainRVAdapter 안에 HomeRVAdapter와 그외 헤더가 있는 구조입니다.
  - 기존에는 새로운 아이템이 받아와지면 MainRVAdpater에 submitList를 하였습니다.
  - MainRVAdapter의 구조는 1: Header, 2: SubHeader, 3: HomeRecyclerView 이렇게 되어있습니다.
  - MainRVAdapter에 submitList를 하면 1번과 2번은 같지만, 3번은 다르게 됩니다. (상태가 바뀐 새로운 List를 제출하였기 때문)
  - 그래서 페이로드든, DiffUtil이든 뭐든 상관 없이 3번은 새로 그려지게 되었고,
  - 그 결과 HomeRecyclerView는 무조건 화면이 깜빡였습니다.
  - 이를 해결하기 위해 MainRVAdapter에 submitList를 하는 것이 아니라, 
  - HomeRVAdapter에 submitList를 하고, MainRVAdpater에는 생성자로 HomeRVAdapter를 넘겨주었습니다.
  - 이거 진짜 밤샜습니다....

### 구현하지 못 한 내용
Main, Soup, Side 탭은 화면 깜빡임 없이 잘 되지만,
Best 탭의 구조는 위 3가지와 달라서 아직 구현에 성공하지 못 했습니다..