### PR TITLE
fix: Horizontal Scroll 중첩 문제 해결

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestViewHolder.kt
@@ -35,10 +35,7 @@ class BestViewHolder(private val binding: ItemBestRecyclerviewBinding, private v
                     MotionEvent.ACTION_MOVE -> {
                         val distanceX = abs(lastX - e.x)
                         val distanceY = abs(lastY - e.y)
-                        if (distanceY > distanceX)
-                            rv.parent.requestDisallowInterceptTouchEvent(false)
-                        else
-                            rv.parent.requestDisallowInterceptTouchEvent(true)
+                        rv.parent.requestDisallowInterceptTouchEvent(distanceY <= distanceX)
                     }
                     MotionEvent.ACTION_UP -> {
                         lastX = 0

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/viewholder/BestViewHolder.kt
@@ -1,20 +1,56 @@
 package com.woowa.banchan.ui.home.best.adapter.viewholder
 
+import android.view.MotionEvent
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.woowa.banchan.databinding.ItemBestRecyclerviewBinding
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.home.best.adapter.BestItemAdapter
+import kotlin.math.abs
 
 class BestViewHolder(private val binding: ItemBestRecyclerviewBinding, private val bestItemAdapter: BestItemAdapter) :
     RecyclerView.ViewHolder(binding.root) {
 
     fun bind(food: List<FoodItem>, categoryName: String) {
         binding.rvBest.adapter = bestItemAdapter
+        binding.rvBest.addOnItemTouchListener(getOnItemTouchListener())
         binding.categoryName = categoryName
         bestItemAdapter.submitList(food)
     }
 
     fun submitList(foods: List<FoodItem>) {
         bestItemAdapter.submitList(foods)
+    }
+
+    private fun getOnItemTouchListener(): RecyclerView.OnItemTouchListener {
+        var lastX = 0
+        var lastY = 0
+        return object : RecyclerView.OnItemTouchListener {
+            override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+                when (e.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        lastX = e.x.toInt()
+                        lastY = e.y.toInt()
+                    }
+                    MotionEvent.ACTION_MOVE -> {
+                        val distanceX = abs(lastX - e.x)
+                        val distanceY = abs(lastY - e.y)
+                        if (distanceY > distanceX)
+                            rv.parent.requestDisallowInterceptTouchEvent(false)
+                        else
+                            rv.parent.requestDisallowInterceptTouchEvent(true)
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        lastX = 0
+                        lastY = 0
+                        rv.parent.requestDisallowInterceptTouchEvent(false)
+                    }
+                }
+                return false
+            }
+
+            override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {}
+            override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
+        }
     }
 }


### PR DESCRIPTION
### ❗️ 이슈
- close #86 

### 📝 구현한 내용
- RecyclerView에 onItemTouchListener 추가

### ❓ 고민한 내용
- 가로스크롤을 신경쓰면 세로가 안 되고, 세로를 신경쓰면 가로가 안 됐습니다.
- 둘 다 잡는 방법이 무엇이 있을까 고민하고 다른 분들 레포를 염탐하던 중..
- 웅재님, 영무님 코드에서 좋은 것을 발견하여.....
- 따왔습니다... 내일 커피한잔 사드려야겠습니다 ㅋㅋㅋㅋ

### 설명

``` kotlin
MotionEvent.ACTION_DOWN -> {
        lastX = e.x.toInt()
        lastY = e.y.toInt()
}
```
`MotionEvent.ACTION_DOWN`은 말 그대로 사용자가 화면을 눌렀을 때 발생합니다.
이때, 마지막으로 터치한 부분의 x좌표와 y좌표를 기록합니다.

``` kotlin
MotionEvent.ACTION_MOVE -> {
        val distanceX = abs(lastX - e.x)
        val distanceY = abs(lastY - e.y)
        if (distanceY > distanceX)
                rv.parent.requestDisallowInterceptTouchEvent(false)
       else
                rv.parent.requestDisallowInterceptTouchEvent(true)
}
```
`MotionEvent.ACTION_MOVE`는 사용자가 터치를 한 상태로 스크롤을 할 때 발생합니다.
이때, 움직인 x의 거리와 y의 거리를 계산하여 lastX, lastY의 거리와의 차이를 계산합니다.

그리고 만약 X축으로 움직인 거리가 더 많다면 requestDisallowInterceptTouchEvent(true)를 통해
RecyclerView가 부모의 터치 이벤트를 뺏어오고,
그 반대라면 false를 설정해줌으로써 터치 이벤트를 부모에게 위임합니다.

``` kotlin
MotionEvent.ACTION_UP -> {
        lastX = 0
        lastY = 0
        rv.parent.requestDisallowInterceptTouchEvent(false)
}
```
`MotionEvent.ACTION_UP`은 사용자가 화면에서 손을 뗐을 때 발생합니다.
이때는 다시 lastX와 lastY를 0으로 만들어주고, 터치 이벤트를 다시 부모에게 위임해줍니다.