### PR TITLE
fix: 카트 화면 깜박임 및 전체 선택 주문 오류 버그 수정

### DIFF
--- a/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/model/Cart.kt
@@ -1,6 +1,6 @@
 package com.woowa.banchan.domain.model
 
-class Cart(
+data class Cart(
     val hash: String,
     var checkState: Boolean,
     val price: Int,

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CheckHeaderViewHolder.kt
@@ -11,8 +11,8 @@ class CheckHeaderViewHolder(
 ) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(checkOriginStateFlag: Int, checkStateFlag: Int) {
-        binding.checkStateFlag = checkStateFlag == checkOriginStateFlag
+    fun bind(checkStateOriginCount: Int, checkStateCount: Int) {
+        binding.checkStateFlag = checkStateCount == checkStateOriginCount
         binding.tvRemoveSelection.setOnClickListener { onClickRemoveSelection() }
         binding.tvAllChecked.setOnClickListener { onClickAllSelection() }
         binding.tvReleaseChecked.setOnClickListener { onClickReleaseSelection() }


### PR DESCRIPTION
### ❗️ 이슈
- close #102 

### 📝 구현한 내용
- 화면의 전체 선택 또는 선택 해제 클릭 시 화면 전체가 깜빡이는 버그를 수정
- 전체 선택 및 선택 해제가 적절히 동작하지 않는 버그 수정

### ❓ 고민한 내용
- 카트의 최상단 헤더 전체 선택 및 선택 해제의 뷰를 보여주기 위한 조건
  - 기존에는 비트 연산으로 카트가 담기는지 안담기는지를 판단했고, 이를 헤더에 전달해 전체 선택을 보여줄 지 선택 해제를 보여줄 지를 결정했다.
  - 하지만 이 비트 연산은 연산이 복잡하고 자칫 잘못했을 경우 오버플로우가 발생하게 되어 적합하지 않다고 고려되었다.
  - 따라서, 카트의 총 개수와 체크가 되어있는 개수를 비교해 보여주는 것으로 결정했다.
