### PR TITLE
refactor: 로딩 시 화면 끊김 대응

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeActivity.kt
@@ -82,6 +82,7 @@ class HomeActivity : AppCompatActivity() {
         TabLayoutMediator(binding.layoutTab, binding.vpHome) { tab, position ->
             tab.text = tabList[position]
         }.attach()
+        binding.vpHome.offscreenPageLimit = 4
     }
 
 }


### PR DESCRIPTION
### ❗️ 이슈
- close #117 

### 📝 구현한 내용
- 프래그먼트 초기화 시 메인스레드에서 하는 작업이 과부하 되는 것이 원인
- 이를 viewpager2의 offscreenPagerLimit을 설정해주어 preload한다.