### PR TITLE
feat: CartFragment 로직 수정

### DIFF
--- a/app/src/main/java/com/woowa/banchan/data/local/dao/CartDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/CartDao.kt
@@ -15,7 +15,7 @@ interface CartDao {
     suspend fun insertCart(cartDto: CartDto)
 
     @Update
-    suspend fun updateCart(cartDto: CartDto)
+    suspend fun updateCart(vararg cartDto: CartDto)
 
     @Query("SELECT * FROM $cartTable")
     fun getCartList(): Flow<List<CartDto>>

--- a/app/src/main/java/com/woowa/banchan/data/local/dao/CartDao.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/dao/CartDao.kt
@@ -1,9 +1,6 @@
 package com.woowa.banchan.data.local.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.Update
+import androidx.room.*
 import com.woowa.banchan.data.local.BanchanDataBase.Companion.cartTable
 import com.woowa.banchan.data.local.entity.CartDto
 import kotlinx.coroutines.flow.Flow
@@ -16,6 +13,9 @@ interface CartDao {
 
     @Update
     suspend fun updateCart(vararg cartDto: CartDto)
+
+    @Delete
+    suspend fun deleteCart(vararg cartDto: CartDto)
 
     @Query("SELECT * FROM $cartTable")
     fun getCartList(): Flow<List<CartDto>>

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
@@ -9,7 +9,7 @@ interface CartDataSource {
 
     suspend fun getCartCount(): Flow<Int>
 
-    suspend fun updateCart(cartDto: CartDto)
+    suspend fun updateCart(vararg cartDto: CartDto)
 
     suspend fun deleteCart(hash: String)
 

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSource.kt
@@ -13,5 +13,7 @@ interface CartDataSource {
 
     suspend fun deleteCart(hash: String)
 
+    suspend fun deleteCart(vararg cartDto: CartDto)
+
     suspend fun insertCart(cartDto: CartDto)
 }

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
@@ -15,8 +15,8 @@ class CartDataSourceImpl @Inject constructor(
 
     override suspend fun getCartCount(): Flow<Int> = cartDao.getCartCount()
 
-    override suspend fun updateCart(cartDto: CartDto) {
-        cartDao.updateCart(cartDto)
+    override suspend fun updateCart(vararg cartDto: CartDto) {
+        cartDao.updateCart(*cartDto)
     }
 
     override suspend fun deleteCart(hash: String) {

--- a/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/datasource/cart/CartDataSourceImpl.kt
@@ -23,6 +23,10 @@ class CartDataSourceImpl @Inject constructor(
         cartDao.deleteCart(hash)
     }
 
+    override suspend fun deleteCart(vararg cartDto: CartDto) {
+        cartDao.deleteCart(*cartDto)
+    }
+
     override suspend fun insertCart(cartDto: CartDto) {
         cartDao.insertCart(cartDto)
     }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -38,6 +38,11 @@ class CartRepositoryImpl @Inject constructor(
             runCatching { cartDataSource.deleteCart(hash) }
         }
 
+    override suspend fun deleteCart(vararg cart: Cart): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            kotlin.runCatching { cartDataSource.deleteCart(*cart.map { it.toCartDto() }.toTypedArray()) }
+        }
+
     override suspend fun insertCart(cart: Cart): Result<Unit> =
         withContext(Dispatchers.IO) {
             runCatching {

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -28,9 +28,9 @@ class CartRepositoryImpl @Inject constructor(
             runCatching { cartDataSource.getCartCount() }
         }
 
-    override suspend fun updateCart(cart: Cart): Result<Unit> =
+    override suspend fun updateCart(vararg cart: Cart): Result<Unit> =
         withContext(Dispatchers.IO) {
-            runCatching { cartDataSource.updateCart(cart.toCartDto()) }
+            runCatching { cartDataSource.updateCart(*cart.map { it.toCartDto() }.toTypedArray()) }
         }
 
     override suspend fun deleteCart(hash: String): Result<Unit> =

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/CartRepositoryImpl.kt
@@ -40,7 +40,7 @@ class CartRepositoryImpl @Inject constructor(
 
     override suspend fun deleteCart(vararg cart: Cart): Result<Unit> =
         withContext(Dispatchers.IO) {
-            kotlin.runCatching { cartDataSource.deleteCart(*cart.map { it.toCartDto() }.toTypedArray()) }
+            runCatching { cartDataSource.deleteCart(*cart.map { it.toCartDto() }.toTypedArray()) }
         }
 
     override suspend fun insertCart(cart: Cart): Result<Unit> =

--- a/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
@@ -9,7 +9,7 @@ interface CartRepository {
 
     suspend fun getCartCount(): Result<Flow<Int>>
 
-    suspend fun updateCart(cart: Cart): Result<Unit>
+    suspend fun updateCart(vararg cart: Cart): Result<Unit>
 
     suspend fun deleteCart(hash: String): Result<Unit>
 

--- a/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/CartRepository.kt
@@ -13,5 +13,7 @@ interface CartRepository {
 
     suspend fun deleteCart(hash: String): Result<Unit>
 
+    suspend fun deleteCart(vararg cart: Cart): Result<Unit>
+
     suspend fun insertCart(cart: Cart): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/DeleteCartUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/DeleteCartUseCaseImpl.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.domain.usecase.cart
 
+import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.repository.CartRepository
 import com.woowa.banchan.domain.usecase.cart.inter.DeleteCartUseCase
 import javax.inject.Inject
@@ -10,4 +11,8 @@ class DeleteCartUseCaseImpl @Inject constructor(
 
     override suspend operator fun invoke(hash: String): Result<Unit> =
         cartRepository.deleteCart(hash)
+
+    override suspend fun invoke(vararg cart: Cart): Result<Unit> =
+        cartRepository.deleteCart(*cart)
+
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/UpdateCartUseCaseImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/UpdateCartUseCaseImpl.kt
@@ -10,7 +10,7 @@ class UpdateCartUseCaseImpl @Inject constructor(
     private val cartRepository: CartRepository
 ) : UpdateCartUseCase {
 
-    override suspend operator fun invoke(cart: Cart): Result<Unit> = cartRepository.updateCart(cart)
+    override suspend operator fun invoke(vararg cart: Cart): Result<Unit> = cartRepository.updateCart(*cart)
 
     override suspend fun invoke(
         detailItem: DetailItem,

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/DeleteCartUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/DeleteCartUseCase.kt
@@ -1,6 +1,10 @@
 package com.woowa.banchan.domain.usecase.cart.inter
 
+import com.woowa.banchan.domain.model.Cart
+
 interface DeleteCartUseCase {
 
     suspend operator fun invoke(hash: String): Result<Unit>
+
+    suspend operator fun invoke(vararg cart: Cart): Result<Unit>
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/UpdateCartUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/cart/inter/UpdateCartUseCase.kt
@@ -5,7 +5,7 @@ import com.woowa.banchan.domain.model.DetailItem
 
 interface UpdateCartUseCase {
 
-    suspend operator fun invoke(cart: Cart): Result<Unit>
+    suspend operator fun invoke(vararg cart: Cart): Result<Unit>
 
     suspend operator fun invoke(
         detailItem: DetailItem,

--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
@@ -1,6 +1,5 @@
 package com.woowa.banchan.ui.cart
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
@@ -104,6 +104,7 @@ class CartViewModel @Inject constructor(
     private fun insertOrder() = viewModelScope.launch {
         _insertionUiState.emit(UiState.Loading)
         val checkedList = cartCache.values.filter { it.checkState }
+        orderTitle = checkedList.first().title
         insertCartToOrderUseCase(checkedList).onSuccess { id ->
             _insertionUiState.emit(UiState.Success(id))
             checkedList.forEach { launch { deleteCartUseCase(it.hash) } }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -26,6 +26,7 @@ import com.woowa.banchan.ui.common.event.EventObserver
 import com.woowa.banchan.ui.common.key.ORDER_ID
 import com.woowa.banchan.ui.common.receiver.OrderReceiver
 import com.woowa.banchan.ui.common.uistate.UiState
+import com.woowa.banchan.ui.common.viewutils.setOrderTitle
 import com.woowa.banchan.ui.detail.DetailActivity
 import com.woowa.banchan.ui.order.detail.OrderDetailActivity
 import com.woowa.banchan.utils.showToast
@@ -133,7 +134,15 @@ class CartFragment : Fragment() {
                 when (state) {
                     is UiState.Success -> {
                         val intent = Intent(requireActivity(), OrderDetailActivity::class.java)
-                        setAlarm(state.data, viewModel.orderTitle)
+
+                        setAlarm(
+                            state.data, setOrderTitle(
+                                viewModel.orderTitle,
+                                viewModel.cartCache.values.filter { it.checkState }.size,
+                                resources
+                            )
+                        )
+
                         intent.putExtra(ORDER_ID, state.data)
                         startActivity(intent)
                         requireActivity().finish()

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -102,12 +102,9 @@ class CartFragment : Fragment() {
             .onEach {
                 when (it) {
                     is UiState.Success -> {
-                        if (viewModel.cartCache.isEmpty()) {
+                        if (viewModel.cartCache.isEmpty())
                             viewModel.cartCache = it.data.toMutableMap()
-                            cartRVAdapter.submitCartList(it.data.values.toList())
-                        } else {
-                            cartRVAdapter.submitCartList(viewModel.cartCache.values.toList())
-                        }
+                        cartRVAdapter.submitCartList(viewModel.cartCache.values.toList())
                     }
                     is UiState.Error -> showToast(it.error.message)
                     else -> {}

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/CartFragment.kt
@@ -71,8 +71,8 @@ class CartFragment : Fragment() {
                 )
             }
 
-            override fun onClickCartRemove(cart: Cart) {
-                viewModel.cartRemoveListener(cart)
+            override fun onClickCartRemove(hash: String) {
+                viewModel.cartRemoveListener(hash)
             }
 
             override fun onClickOrderButton() {

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -239,7 +239,7 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
     interface CartButtonCallBackListener {
 
         fun onClickCartUpdate(cart: Cart, message: Int? = null)
-        fun onClickCartRemove(cart: Cart)
+        fun onClickCartRemove(hash: String)
         fun onClickOrderButton()
         fun onClickRecentItem(recent: Recent)
         fun onClickAllRecentlyViewed()

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/CartRVAdapter.kt
@@ -49,8 +49,8 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
                     ), parent, false
                 ),
                 onClickCartRemove = { onClickCartRemove(it) },
-                onClickCartCheckState = { onClickCartCheckState(it) },
-                onClickCartUpdateCount = { cart, message -> onClickCartUpdateCount(cart, message) }
+                onClickCartStateChange = { onClickCartStateChange(it) },
+                onClickCartCountChange = { cart -> onClickCartCountChange(cart) }
             )
             CART_TOTAL_PRICE -> {
                 totalPriceViewHolder = TotalPriceViewHolder(
@@ -165,46 +165,36 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
     }
 
     private fun onClickRemoveSelection() {
-        val removedList = cartList.filter {
-            if (it.checkState) {
-                listener?.onClickCartRemove(it)
-                false
-            } else true
-        }
-        submitCartList(removedList)
+        listener?.onClickCartRemove(*cartList.filter { it.checkState }.toTypedArray())
     }
 
     private fun onClickAllSelection() {
-        val newList = cartList.map { cart ->
-            cart.copy(checkState = true).apply { listener?.onClickCartUpdate(this) }
-        }
+        val newList = cartList.map { cart -> cart.copy(checkState = true) }
+        listener?.onClickCartStateAllChange(newList)
         submitCartList(newList)
     }
 
     private fun onClickReleaseSelection() {
-        val newList = cartList.map { cart ->
-            cart.copy(checkState = false).apply { listener?.onClickCartUpdate(this) }
-        }
+        val newList = cartList.map { cart -> cart.copy(checkState = false) }
+        listener?.onClickCartStateAllChange(newList)
         submitCartList(newList)
     }
 
-    private fun onClickCartCheckState(cart: Cart) {
+    private fun onClickCartStateChange(cart: Cart) {
         checkStateCount = if (cart.checkState) checkStateCount + 1 else checkStateCount - 1
         checkHeaderViewHolder?.bind(checkStateOriginCount, checkStateCount)
         cartList.map { if (it.hash == cart.hash) it.checkState = cart.checkState }
+        listener?.onClickCartStateChange(cart.hash, cart.checkState)
         updateTotalPrice()
-        listener?.onClickCartUpdate(cart)
     }
 
-    private fun onClickCartUpdateCount(cart: Cart, message: Int? = null) {
+    private fun onClickCartCountChange(cart: Cart) {
         cartList.map { if (it.hash == cart.hash) it.count = cart.count }
+        listener?.onClickCartCountChange(cart.hash, cart.count)
         updateTotalPrice()
-        listener?.onClickCartUpdate(cart, message)
     }
 
     private fun onClickCartRemove(cart: Cart) {
-        val removedList = cartList.filter { cart.hash != it.hash }
-        submitCartList(removedList)
         listener?.onClickCartRemove(cart)
     }
 
@@ -237,11 +227,12 @@ class CartRVAdapter : ListAdapter<Cart, RecyclerView.ViewHolder>(diffUtil) {
     }
 
     interface CartButtonCallBackListener {
-
-        fun onClickCartUpdate(cart: Cart, message: Int? = null)
-        fun onClickCartRemove(hash: String)
+        fun onClickCartRemove(vararg cart: Cart)
         fun onClickOrderButton()
         fun onClickRecentItem(recent: Recent)
         fun onClickAllRecentlyViewed()
+        fun onClickCartCountChange(hash: String, count: Int)
+        fun onClickCartStateChange(hash: String, checkState: Boolean)
+        fun onClickCartStateAllChange(cartList: List<Cart>)
     }
 }

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
@@ -59,11 +59,12 @@ class CartContentViewHolder(
     }
 
     private fun updateCount(count: String) {
-        binding.itemCount = count
         val count = if (count.isEmpty()) 0 else count.toInt()
 
         cart.count = if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
         binding.cart = cart
+        binding.itemCount = cart.count.toString()
+
         onClickCartCountChange(cart)
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
@@ -4,7 +4,6 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.recyclerview.widget.RecyclerView
-import com.woowa.banchan.R
 import com.woowa.banchan.databinding.ItemCartBinding
 import com.woowa.banchan.domain.model.Cart
 import com.woowa.banchan.domain.model.emptyCart
@@ -13,9 +12,9 @@ import com.woowa.banchan.ui.cart.cart.CartFragment.Companion.minimumCount
 
 class CartContentViewHolder(
     private val binding: ItemCartBinding,
-    private val onClickCartCheckState: (cart: Cart) -> Unit,
-    private val onClickCartUpdateCount: (cart: Cart, message: Int?) -> Unit,
-    private val onClickCartRemove: (cart: Cart) -> Unit
+    private val onClickCartStateChange: (cart: Cart) -> Unit,
+    private val onClickCartCountChange: (cart: Cart) -> Unit,
+    private val onClickCartRemove: (cart: Cart) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
     private var cart = emptyCart()
@@ -44,34 +43,28 @@ class CartContentViewHolder(
         binding.layoutCheckBtn.setOnClickListener {
             cart.checkState = cart.checkState.not()
             binding.cart = cart
-            onClickCartCheckState(cart)
+            onClickCartStateChange(cart)
         }
         binding.ivMinusCount.setOnClickListener { updateCount(cart.count - 1) }
         binding.ivPlusCount.setOnClickListener { updateCount(cart.count + 1) }
         binding.ivRemove.setOnClickListener { onClickCartRemove(cart) }
     }
 
-    private fun updateCount(c: Int) {
-        val msg: Int? = if (c < minimumCount || c > maximumCount) overflowMessage else null
-        cart.count =
-            if (c < minimumCount) minimumCount else if (c > maximumCount) maximumCount else c
+    private fun updateCount(count: Int) {
+        cart.count = if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
 
         binding.itemCount = cart.count.toString()
         binding.cart = cart
-        onClickCartUpdateCount(cart, msg)
+        onClickCartCountChange(cart)
     }
 
-    private fun updateCount(c: String) {
-        binding.itemCount = c
-        val count = if (c.isEmpty()) 0 else c.toInt()
+    private fun updateCount(count: String) {
+        binding.itemCount = count
+        val count = if (count.isEmpty()) 0 else count.toInt()
 
-        val msg: Int? =
-            if (count < minimumCount || count > maximumCount) overflowMessage else null
-        cart.count =
-            if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
+        cart.count = if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
         binding.cart = cart
-        onClickCartUpdateCount(cart, msg)
+        onClickCartCountChange(cart)
     }
 
-    private val overflowMessage = R.string.error_item_count_overflow
 }

--- a/app/src/main/java/com/woowa/banchan/ui/common/recyclerview/RVItem.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/recyclerview/RVItem.kt
@@ -1,0 +1,26 @@
+package com.woowa.banchan.ui.common.recyclerview
+
+sealed class RVItem {
+    abstract val id: Int
+
+    object Header : RVItem() {
+        override val id = 0
+    }
+
+    object SubHeader : RVItem() {
+        override val id = 1
+    }
+
+    object Footer : RVItem() {
+        override val id = 2
+    }
+
+    data class Item<T>(val item: T) : RVItem() { // 아이템 항목
+        override val id = 3
+    }
+
+    object Empty : RVItem() {
+        override val id = Integer.MAX_VALUE
+    }
+
+}

--- a/app/src/main/java/com/woowa/banchan/ui/common/viewutils/TextViewUtil.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/common/viewutils/TextViewUtil.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.ui.common.viewutils
 
+import android.content.res.Resources
 import android.graphics.Paint
 import android.view.View
 import android.widget.TextView
@@ -83,13 +84,16 @@ fun TextView.setOriginPrice(nPrice: Int?, sPrice: Int?) {
 
 @BindingAdapter("thumbnailTitle", "itemCount")
 fun TextView.setOrderSummaryText(thumbnailTitle: String, itemCount: Int) {
-    text = if (itemCount > 1) {
-        resources.getString(R.string.text_view_order_summary, thumbnailTitle, itemCount)
-    } else thumbnailTitle
+    text = setOrderTitle(thumbnailTitle, itemCount, resources)
 }
 
 @BindingAdapter("time")
 fun TextView.setTime(time: Date) {
     val leftTime = (System.currentTimeMillis() - time.time) / 60000
-    text = "${(1 - leftTime.toInt())}분"
+    text = "${(1 - leftTime.toInt())}${resources.getString(R.string.order_minute)}"
 }
+
+fun setOrderTitle(thumbnailTitle: String, itemCount: Int, resources: Resources): String =
+    if (itemCount > 1) {
+        resources.getString(R.string.text_view_order_summary, thumbnailTitle, itemCount - 1)
+    } else thumbnailTitle

--- a/app/src/main/java/com/woowa/banchan/ui/home/HomeRVTag.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/HomeRVTag.kt
@@ -8,27 +8,3 @@ const val LINEAR_VERTICAL = 4
 const val LINEAR_HORIZONTAL = 5
 const val GRID = 6
 
-sealed class RVItem {
-    abstract val id: Int
-
-    object Header : RVItem() {
-        override val id = 0
-    }
-
-    object SubHeader : RVItem() {
-        override val id = 1
-    }
-
-    object Footer : RVItem() {
-        override val id = 2
-    }
-
-    data class Item<T>(val item: T) : RVItem() { // 아이템 항목
-        override val id = 3
-    }
-
-    object Empty : RVItem() {
-        override val id = Integer.MAX_VALUE
-    }
-
-}

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
@@ -10,9 +10,9 @@ import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemSoupSideHeaderBinding
 import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.home.HOME_HEADER
 import com.woowa.banchan.ui.home.HOME_ITEM
-import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.home.SUB_HEADER
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.soupside.viewholder.SoupSideHeaderViewHolder

--- a/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/adapter/soupside/SoupSideRVAdapter.kt
@@ -12,7 +12,7 @@ import com.woowa.banchan.databinding.ItemSoupSideHeaderBinding
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.home.HOME_HEADER
 import com.woowa.banchan.ui.home.HOME_ITEM
-import com.woowa.banchan.ui.home.RVItem
+import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.home.SUB_HEADER
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.soupside.viewholder.SoupSideHeaderViewHolder

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -11,7 +11,7 @@ import com.woowa.banchan.domain.model.BestFoodCategory
 import com.woowa.banchan.domain.model.FoodItem
 import com.woowa.banchan.ui.home.HOME_HEADER
 import com.woowa.banchan.ui.home.HOME_ITEM
-import com.woowa.banchan.ui.home.RVItem
+import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestViewHolder
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/best/adapter/BestRVAdapter.kt
@@ -9,9 +9,9 @@ import com.woowa.banchan.databinding.ItemBestRecyclerviewBinding
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.domain.model.BestFoodCategory
 import com.woowa.banchan.domain.model.FoodItem
+import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.home.HOME_HEADER
 import com.woowa.banchan.ui.home.HOME_ITEM
-import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.best.adapter.viewholder.BestViewHolder
 

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -10,6 +10,7 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemMainHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
+import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.home.*
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder

--- a/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/home/main/adapter/MainRVAdapter.kt
@@ -11,7 +11,10 @@ import com.woowa.banchan.databinding.ItemHomeHeaderBinding
 import com.woowa.banchan.databinding.ItemMainHeaderBinding
 import com.woowa.banchan.databinding.ItemRecyclerviewBinding
 import com.woowa.banchan.ui.common.recyclerview.RVItem
-import com.woowa.banchan.ui.home.*
+import com.woowa.banchan.ui.home.GRID
+import com.woowa.banchan.ui.home.HOME_HEADER
+import com.woowa.banchan.ui.home.HOME_ITEM
+import com.woowa.banchan.ui.home.SUB_HEADER
 import com.woowa.banchan.ui.home.adapter.HomeRVAdapter
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeHeaderViewHolder
 import com.woowa.banchan.ui.home.adapter.viewholder.HomeRecyclerViewViewHolder

--- a/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/OrderDetailRVAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/order/detail/adapter/OrderDetailRVAdapter.kt
@@ -11,7 +11,7 @@ import com.woowa.banchan.databinding.ItemTotalPriceBinding
 import com.woowa.banchan.domain.model.Order
 import com.woowa.banchan.domain.model.OrderItem
 import com.woowa.banchan.ui.cart.cart.adapter.viewholder.TotalPriceViewHolder
-import com.woowa.banchan.ui.home.RVItem
+import com.woowa.banchan.ui.common.recyclerview.RVItem
 import com.woowa.banchan.ui.order.detail.ORDER_CONTENT
 import com.woowa.banchan.ui.order.detail.ORDER_HEADER
 import com.woowa.banchan.ui.order.detail.ORDER_TOTAL_PRICE

--- a/app/src/main/res/layout/activity_order_detail.xml
+++ b/app/src/main/res/layout/activity_order_detail.xml
@@ -20,7 +20,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:onClickBackIcon="@{vm::setBackClickEvent}"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="order_total_count">총 %d개</string>
     <string name="order_item_count">%d개</string>
     <string name="order_left_minute">%d분</string>
+    <string name="order_minute">분</string>
 
     <!--Cart Screen-->
     <string name="cart_selection_release">선택 해제</string>


### PR DESCRIPTION
### ❗️ 이슈
- close #130 

한번에 많은 이슈를 해결하게 돼서 죄송합니다....

### 📝 구현한 내용
- update와 delete가 리스트가 리스트로 처리될 수 있도록 vararg로 변경
- delete는 즉각 처리, update는 일괄 처리 되도록 변경
- 체크된 것만 캐시가 되는 것이 아닌 현재 화면에 보이는 모든 카트를 ViewModel에 저장해 두었다가 화면에서 벗어날 때 업데이트 되도록 변경

### ❓ 고민한 내용
주호님이랑 하루종일 상의했습니다.............