### PR TITLE
fix: recent에서 카트 추가할 때 장바구니 화면이 변화되지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartViewModel.kt
@@ -87,6 +87,7 @@ class CartViewModel @Inject constructor(
 
     fun updateCart() = CoroutineScope(Dispatchers.IO).launch {
         updateCartUseCase(*cartCache.values.toTypedArray())
+        cartCache = mutableMapOf()
     }
 
     fun deleteCart(recent: Recent) {


### PR DESCRIPTION
### ❗️ 이슈
- close #133 

### 📝 구현한 내용
- 장바구니 화면에서 recent view로 넘어갈 때 cartCache를 업데이트한다.
- 업데이트를 하고 캐시를 비워주어야 하지만 이를 수행하지 않음
- 이로인해 생긴 버그를 고침