### PR TITLE
fix: cart 화면 수량 버그 수정

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
@@ -51,7 +51,8 @@ class CartContentViewHolder(
     }
 
     private fun updateCount(count: Int) {
-        cart.count = if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
+        cart.count =
+            if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
 
         binding.itemCount = cart.count.toString()
         binding.cart = cart
@@ -59,9 +60,14 @@ class CartContentViewHolder(
     }
 
     private fun updateCount(count: String) {
-        val count = if (count.isEmpty()) 0 else count.toInt()
 
-        cart.count = if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
+        val countStr = count.replace(".", "")
+        if (countStr.length == 3) binding.etCount.setSelection(3)
+
+        val countInt = if (count.isEmpty()) 0 else countStr.toInt()
+
+        cart.count =
+            if (countInt < minimumCount) minimumCount else if (countInt > maximumCount) maximumCount else countInt
         binding.cart = cart
         binding.itemCount = cart.count.toString()
 


### PR DESCRIPTION
### ❗️ 이슈
- close #146 

### 📝 구현한 내용
- 화면 수량 입력 시 max 값 도달되면 커서가 앞으로 이동함
    - 맥스값에 도달하면, 커서를 마지막으로 위치하게 함
- . 입력 시 앱 크래시
    - .이 들어간 string을 toInt를 통해 변환하는 것 때문에 발생한 버그
    - 이를 변경함