### PR TITLE
fix: Recent -> Detail -> Cart 이동 스택 관리

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartActivity.kt
@@ -1,5 +1,6 @@
 package com.woowa.banchan.ui.cart
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -24,6 +25,11 @@ class CartActivity : AppCompatActivity() {
 
         initBinding()
         initObserver()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        viewModel.setFragmentTag(getString(R.string.fragment_cart))
     }
 
     private fun initBinding() {

--- a/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/cart/adapter/viewholder/CartContentViewHolder.kt
@@ -51,7 +51,8 @@ class CartContentViewHolder(
     }
 
     private fun updateCount(count: Int) {
-        cart.count = if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
+        cart.count =
+            if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
 
         binding.itemCount = cart.count.toString()
         binding.cart = cart
@@ -59,9 +60,14 @@ class CartContentViewHolder(
     }
 
     private fun updateCount(count: String) {
-        val count = if (count.isEmpty()) 0 else count.toInt()
 
-        cart.count = if (count < minimumCount) minimumCount else if (count > maximumCount) maximumCount else count
+        val countStr = count.replace(".", "")
+        if (countStr.length == 3) binding.etCount.setSelection(3)
+
+        val countInt = if (count.isEmpty()) 0 else countStr.toInt()
+
+        cart.count =
+            if (countInt < minimumCount) minimumCount else if (countInt > maximumCount) maximumCount else countInt
         binding.cart = cart
         binding.itemCount = cart.count.toString()
 


### PR DESCRIPTION
### ❗️ 이슈
- close #149 

### 📝 구현한 내용
- Recent -> Detail -> Cart 이동 시 Cart 화면이 아닌 기존 Recent 화면이 보여지는 버그를 해결

### ❓ 고민한 내용
- Cart Activity를 우린 SingleTask로 구현했다.    
- 그래서 두 개 이상의 같은 화면이 발생하지 않도록 막았다.
- 하지만 다시 호출할 때 기존 태스크를 그대로 불러온다는 단점이 있었다.
  - Recent 뷰를 보여주고 있는 태스크를 그대로 불러와 생긴 버그이다.
- 그래서 이전 태스크를 지우고 새로 만들까를 고민했으나 공식문서를 한번 읽어보았다.
```
"singleTask"
The system creates the activity at the root of a new task or locates the activity on an existing task with the same affinity. If an instance of the activity already exists and is at the root of the task, the system routes the intent to existing instance through a call to its [onNewIntent()](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)) method, rather than creating a new instance. Meanwhile all of the other activities on top of it are destroyed.
```
- 즉 다시 생성하는 것이 아니라 onNewIntent를 호출해서 기존 인스턴스로 이동한다.
- 그렇다면 onNewIntent를 오버라이딩해서 cart tag로 변경한다.
- 이를 적용해 버그를 해결햇다.